### PR TITLE
feat(sentinel): Stage 2.2 IF hardening, actuator ordering fix, and Stage 2.3 validation docs

### DIFF
--- a/IMPLEMENTATION_STATUS.md
+++ b/IMPLEMENTATION_STATUS.md
@@ -1,0 +1,175 @@
+# AI-Sentinel — Implementation Status
+
+This document summarizes what has been built and what has been done to date (codebase state, review-driven fixes, and verification).
+
+---
+
+## 1. Project Overview
+
+**AI-Sentinel** is a modular Spring Boot starter for **AI-assisted zero-trust API defense**: per-request behavioral anomaly detection, risk scoring, policy-driven enforcement (allow / throttle / block / quarantine), and telemetry. It uses in-process, unsupervised ML (statistical baseline + optional Isolation Forest) with privacy-aware features and fail-open behavior.
+
+**References:**
+
+- **Architecture:** `ARCHITECTURE.md` — design goals, module layout, request lifecycle, interfaces.
+- **Production review:** `docs/review-feedback.md` — full code review (sections A–G).
+- **Audit:** `docs/AUDIT_RESULTS.md` — strict audit of each review issue (FIXED / NOT FIXED).
+- **P0 verification:** `P0_VERIFICATION.md` — manual verification steps for P0 fixes.
+
+---
+
+## 2. Development Stage (vs. Formal Roadmap)
+
+The project follows a staged roadmap: **Stage 0** (core engine) → **Stage 1** (Spring Boot integration) → **Stage 2** (real ML) → **Stage 3** (security hardening) → **Stage 4** (observability) → **Stage 5** (distributed) → **Stage 6** (research).
+
+**Current position: Stage 2 in progress.**
+
+| Stage | Name | Status | Notes |
+|-------|------|--------|--------|
+| **0** | Core Engine Foundation | **Complete** | FeatureExtractor, StatisticalScorer (Welford), warmup, ThresholdPolicyEngine, enforcement (Composite + MonitorOnly), CompositeScorer, TelemetryEmitter, bounded maps (TTL + maxKeys), concurrency fixes, unit + concurrency tests. Deterministic scoring, thread-safe state, no unbounded maps. |
+| **1** | Spring Boot Operational Integration | **Complete** | AutoConfiguration, SentinelFilter, application config (enabled, mode, warmup, trusted-proxies, map sizes/TTL, telemetry). Actuator endpoint with quarantineCount. Fail-open, MONITOR/ENFORCE. Gaps: policy thresholds not in config (D4), filter order fixed (D6), actuator cache sizes not yet (D8 partial). |
+| **2** | Real ML Integration | **In progress** | Bounded training buffer, minimal in-core Isolation Forest (fixed seed, path-length score), IsolationForestScorer with fallback when no model, async retrain via scheduler, actuator metadata (lastRetrainTime, modelVersion, bufferedSampleCount, modelLoaded). Config: training-buffer-size, min-training-samples, retrain-interval, random-seed, score-weight, sample-rate, fallback-score. Inference lock-free; training failures do not affect request path. |
+| **3** | Security Hardening & Adversarial Defense | **Partial** | Proxy trust (trusted-proxies, X-Forwarded-For / Forwarded / X-Real-IP) done. CIDR not supported (exact IP list only). Per-endpoint quarantine (E4), poisoning resistance, gradual enforcement ramp, 5k RPS stress tests — not done. |
+| **4** | Observability & SRE Maturity | **Partial** | Micrometer counters, JSON logging, actuator basic info. Missing: score histograms, cache/eviction metrics, scoring latency p95/p99, fail-open counters, OpenTelemetry. |
+| **5** | Distributed & Enterprise | **Not started** | Redis store, shared quarantine, cluster coordination, tenant isolation, admin API — none. |
+| **6** | Research & Publication | **Not started** | Benchmarks, FP/FN study, adversarial sim, whitepaper — none. |
+
+**Summary:** Stage 0 and Stage 1 are done; Stage 2 is **in progress** (real Isolation Forest scoring, bounded buffer, async retrain, actuator metadata). The codebase is a production-deployable anomaly filter with statistical + optional IF scoring. Stage 3–4 have partial progress; Stages 5–6 are ahead.
+
+---
+
+## 3. Module Layout
+
+| Module | Purpose |
+|--------|---------|
+| **ai-sentinel-core** | Feature extraction, scoring (Statistical + Isolation Forest), policy (ThresholdPolicyEngine), enforcement (Composite + MonitorOnly), telemetry events, baseline store. |
+| **ai-sentinel-spring-boot-starter** | Auto-configuration, `SentinelFilter`, `SentinelProperties`, actuator endpoint `/actuator/sentinel`. |
+| **ai-sentinel-demo** | Sample Spring Boot app with `/api/hello`, simulated traffic, MONITOR/ENFORCE config. |
+
+Build: Maven multi-module (root `pom.xml`). Run demo: `mvn -pl ai-sentinel-demo spring-boot:run`.
+
+---
+
+## 4. What Has Been Implemented
+
+### 4.1 Core pipeline
+
+- **Feature extraction** — `DefaultFeatureExtractor`: `requestsPerWindow`, `endpointEntropy`, `tokenAgeSeconds`, `parameterCount`, `payloadSizeBytes`, `headerFingerprintHash`, `ipBucket`. Uses `BaselineStore` (time-bucketed counts) and per-identity endpoint history for entropy.
+- **Scoring** — `StatisticalScorer` (Welford rolling mean/std, z-score → sigmoid), `CompositeScorer` (weighted combination), optional `IsolationForestScorer` (bounded buffer, minimal in-core Isolation Forest, async retrain, fallback score when no model). Score in [0, 1].
+- **Policy** — `ThresholdPolicyEngine`: score bands → ALLOW, MONITOR, THROTTLE, BLOCK, QUARANTINE.
+- **Enforcement** — `CompositeEnforcementHandler`: throttle (token bucket), block (status code), quarantine (time-bound). `MonitorOnlyEnforcementHandler` wraps it in MONITOR mode (no blocking, still reports quarantine state).
+- **Telemetry** — `TelemetryEmitter` (e.g. `DefaultTelemetryEmitter`: JSON logs + Micrometer counters), configurable verbosity.
+
+### 4.2 Spring Boot integration
+
+- **Filter** — `SentinelFilter`: identity resolution (IP + optional Spring Security principal), pipeline invocation, exclude paths, MONITOR vs ENFORCE.
+- **Configuration** — `SentinelProperties`: enabled, mode, excludePaths, blockStatusCode, quarantineDurationMs, throttleRequestsPerSecond, baselineTtl, baselineMaxKeys, internalMapMaxKeys, internalMapTtl, trustedProxies, warmupMinSamples, warmupScore, isolationForest, telemetry.
+- **Actuator** — `/actuator/sentinel`: enabled, mode, isolationForestEnabled, quarantineCount; when IF enabled also **isolationForestModelLoaded**, **isolationForestBufferedSampleCount**, **isolationForestModelVersion**, **isolationForestLastRetrainTimeMillis**, **isolationForestModelAgeMillis**, **isolationForestRetrainFailureCount**, **isolationForestLastRetrainFailureTimeMillis**.
+
+#### Stage 2.2 — Operational Hardening
+
+Stage 2 infrastructure (Isolation Forest scoring, buffer, async retrain, actuator metadata) is **complete**. Stage 2.2 adds operational maturity and model validation capabilities without changing the core architecture:
+
+- **Retrain observability** — IsolationForestScorer logs retrain success (model version, sample count, duration) and logs retrain failures at WARN; exposes **retrainFailureCount** and **lastRetrainFailureTimeMillis** via actuator.
+- **Model age visibility** — `getModelAgeMillis()` (age in ms or -1 if no model); exposed as **isolationForestModelAgeMillis** on `/actuator/sentinel`.
+- **Improved cold-start** — First retrain runs after `min(retrainInterval, 30s)`; subsequent runs use the configured retrain interval.
+- **Configurable IF hyperparameters** — `ai.sentinel.isolation-forest.num-trees` (default 100) and `ai.sentinel.isolation-forest.max-depth` (default 10) wired from SentinelProperties → IsolationForestConfig → IsolationForestTrainer.
+- **Training-data quality gate** — When a model exists, samples with score > 0.7 are not added to the buffer, reducing poisoning from clearly anomalous requests.
+
+### 4.3 Security and robustness (review-driven)
+
+Addressed items from the production review and audit:
+
+| Area | What was done |
+|------|----------------|
+| **Concurrency / data races** | A1/C1: `StatisticalScorer` — `score()` and `update()` use same lock on `WelfordState`; reads via `getMeansCopy()` / `getStds()` under lock. C4: `CompositeEnforcementHandler.isQuarantined()` uses `quarantinedUntil.compute()` for atomic check-and-remove (no TOCTOU). |
+| **Proxy identity** | A5: `SentinelFilter.resolveClientIp(request, trustedProxies)` — when remote is in trusted list, client IP from X-Forwarded-For (leftmost), Forwarded `for=`, or X-Real-IP. Config: `ai.sentinel.trusted-proxies`. |
+| **Map growth / OOM** | A4: All four maps bounded: `stateByKey`, `endpointHistory`, `throttleTokens`, `quarantinedUntil` use maxKeys + TTL/expiry; eviction in StatisticalScorer, DefaultFeatureExtractor, CompositeEnforcementHandler. Config: `internalMapMaxKeys`, `internalMapTtl`. |
+| **Endpoint history** | A2: Atomic counters (`AtomicIntegerArray`) and saturation at `MAX_HISTORY_COUNT` to avoid overflow/NaN. A3: `safeHistoryIndex()` — no `Math.abs(Integer.MIN_VALUE)`; index in [0, HISTORY_SIZE). |
+| **NaN / bypass** | A6: NaN and negative scores clamped to high risk: `SentinelPipeline.clampScore()`, `CompositeScorer`, `StatisticalScorer` (z/sigmoid NaN handling). Policy then sees 1.0 → no ALLOW bypass. |
+| **Cold start** | D3: `StatisticalScorer` warmup — when state is null or `n < warmupMinSamples`, return `warmupScore` (default 0.4) instead of 0.0. Config: `warmupMinSamples`, `warmupScore`. |
+| **Path parameter explosion** | E2: `DefaultFeatureExtractor.normalizeEndpoint()` — truncate to 256 chars; `normalizePathParams()` replaces numeric and UUID path segments with `{id}` so `/api/users/123` and `/api/users/456` share one baseline. |
+| **Monitor visibility** | A7: `MonitorOnlyEnforcementHandler.isQuarantined()` delegates to delegate; actuator `info()` exposes `quarantineCount` from `CompositeEnforcementHandler.getQuarantineCount()`. |
+
+---
+
+## 5. Tests Added / Updated
+
+- **StatisticalScorerTest:** `stateByKeyEvictsWhenOverMaxKeys`, `concurrentUpdateAndScoreNoDataRace`, `scoreReturnsWarmupScoreWhenInsufficientData`, `warmupScoreConfigurable`.
+- **DefaultFeatureExtractorTest:** `endpointWithHashCodeIntegerMinValueDoesNotThrow`, `endpointHistoryEvictsWhenOverMaxKeys`, `pathParamsNormalizedToPreventMapExplosion`, `uuidPathParamNormalized`, `normalizePathParamsStaticMethod`.
+- **CompositeScorerTest:** `nanScoreReturnsOneNotBypass`, `negativeScoreReturnsOne`.
+- **CompositeEnforcementHandlerTest:** `throttleMapBoundedWhenOverMaxKeys`, `quarantineBoundedMapDoesNotThrow`, `getQuarantineCountReturnsActiveQuarantines`, `isQuarantinedExpiredEntryRemovedAtomically`.
+- **MonitorOnlyEnforcementHandlerTest:** `isQuarantinedDelegatesToDelegate`.
+- **SentinelFilterProxyTest:** trusted proxy + X-Forwarded-For / Forwarded / X-Real-IP behavior.
+- **SentinelActuatorEndpointTest:** endpoint structure, `quarantineCount`, and when IF enabled the IF metadata keys.
+- **BoundedTrainingBufferTest:** boundedness, snapshot, concurrent adds, null/empty ignored.
+- **IsolationForestScorerTest:** fallback when no model, score in [0,1] after training, retrain failure does not break inference, atomic model swap, metadata.
+- **Demo:** `DemoIntegrationTest` (hello + actuator); test profile uses MONITOR and higher throttle for stability.
+
+---
+
+## 6. Configuration (High Level)
+
+Example `application.yaml`:
+
+```yaml
+ai:
+  sentinel:
+    enabled: true
+    mode: ENFORCE   # or MONITOR, OFF
+    exclude-paths: /actuator/**,/health,/health/**
+    trusted-proxies: 127.0.0.1,::1
+    internal-map-max-keys: 100_000
+    internal-map-ttl: 5m
+    warmup-min-samples: 2
+    warmup-score: 0.4
+    throttle-requests-per-second: 5.0
+    isolation-forest:
+      enabled: false
+      training-buffer-size: 10_000
+      min-training-samples: 100
+      retrain-interval: 5m
+      random-seed: 42
+      score-weight: 0.5
+      sample-rate: 0.1
+      fallback-score: 0.5
+      num-trees: 100
+      max-depth: 10
+```
+
+---
+
+## 7. What Is Not Done (Deferred)
+
+From the audit, the following remain **not fixed** or **partially fixed** (see `docs/AUDIT_RESULTS.md` for full table):
+
+- **Performance:** B1–B7 (e.g. MessageDigest per request, reflection per request, string concat hot path, telemetry streams, Counter.builder per emit, BaselineStore eviction stampede, multiple `currentTimeMillis`).
+- **Concurrency:** C2 (BaselineStore bucket count window), C3 (CompositeScorer ArrayList).
+- **Design / ops:** D1 (RequestContext unused), D2 (hash features in z-score), D4–D7 (policy thresholds not in properties, no Content-Type on error, filter order, no graceful degradation), D8 (actuator only has quarantineCount so far).
+- **Edge cases:** E1, E3–E7 (token age semantics, response committed, quarantine scope, BaselineStore TTL cliff, entropy gaming, parameterCount for JSON).
+
+These are documented in the audit with evidence and recommended follow-up.
+
+---
+
+## 8. How to Build and Test
+
+```bash
+# From repo root
+mvn clean test -q
+# Expect: BUILD SUCCESS
+
+# Run demo
+mvn -pl ai-sentinel-demo spring-boot:run
+# Then: curl http://localhost:8080/api/hello
+#       curl http://localhost:8080/actuator/sentinel
+```
+
+---
+
+## 9. Repo Hygiene
+
+- **.gitignore:** `design_info.txt`, `docs/`, `target/`, `**/target/`, `**/build/`, `**/out/`, IDE/OS patterns. Previously committed `target/` directories were removed from the Git index with `git rm -r --cached ...` so they are no longer tracked.
+
+---
+
+*Last updated to reflect implementation and audit state as of the current codebase.*

--- a/README.md
+++ b/README.md
@@ -72,3 +72,21 @@ curl http://localhost:8080/actuator/sentinel
 - **ai-sentinel-core** — Feature extraction, StatisticalScorer, policy, enforcement
 - **ai-sentinel-spring-boot-starter** — Auto-configuration, filter, actuator
 - **ai-sentinel-demo** — Sample API + traffic simulator
+
+## Developer utilities
+
+### Stage 2: Isolation Forest training monitor
+
+With Isolation Forest enabled, generate traffic and watch the model train:
+
+```bash
+# Start demo with ai.sentinel.isolation-forest.enabled=true (see scripts/README.md)
+mvn -pl ai-sentinel-demo spring-boot:run
+
+# In another terminal: send traffic and poll until model is loaded
+python scripts/train_monitor.py
+```
+
+Options: `--base-url`, `--traffic-endpoint`, `--total-requests`, `--concurrency`, `--poll-interval`, `--request-delay-ms`. See **scripts/README.md** for details.
+
+**Traffic simulator** (`scripts/traffic_simulator.py`) — Generate normal, burst, or attack-style traffic with randomized headers, query params, and payload sizes. Options: `--mode normal|burst|attack`, `--base-url`, `--duration`, `--requests-per-second`, `--concurrency`. Prints requests sent, errors, and latency stats.

--- a/ai-sentinel-core/src/main/java/io/aisentinel/core/scoring/BoundedTrainingBuffer.java
+++ b/ai-sentinel-core/src/main/java/io/aisentinel/core/scoring/BoundedTrainingBuffer.java
@@ -1,0 +1,76 @@
+package io.aisentinel.core.scoring;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.locks.ReentrantLock;
+
+/**
+ * Thread-safe bounded ring buffer for feature vectors used to train Isolation Forest.
+ * When full, oldest entries are overwritten. No unbounded growth.
+ */
+public final class BoundedTrainingBuffer {
+
+    private final double[][] ring;
+    private final int maxSize;
+    private final AtomicInteger size = new AtomicInteger(0);
+    private int writeIndex;
+    private final ReentrantLock writeLock = new ReentrantLock();
+
+    public BoundedTrainingBuffer(int maxSize) {
+        this.maxSize = Math.max(1, maxSize);
+        this.ring = new double[this.maxSize][];
+        this.writeIndex = 0;
+    }
+
+    /**
+     * Appends a copy of the feature vector. If buffer is full, overwrites oldest.
+     * Thread-safe.
+     */
+    public void add(double[] features) {
+        if (features == null || features.length == 0) return;
+        double[] copy = Arrays.copyOf(features, features.length);
+        writeLock.lock();
+        try {
+            ring[writeIndex] = copy;
+            writeIndex = (writeIndex + 1) % maxSize;
+            int s = size.get();
+            if (s < maxSize) size.set(s + 1);
+        } finally {
+            writeLock.unlock();
+        }
+    }
+
+    /**
+     * Current number of samples (capped at maxSize).
+     */
+    public int size() {
+        return size.get();
+    }
+
+    /**
+     * Returns a snapshot of all stored vectors for training. Order is unspecified.
+     * Caller must not modify the inner arrays. Safe to call while other threads add.
+     */
+    public List<double[]> getSnapshotForTraining() {
+        writeLock.lock();
+        try {
+            int n = size.get();
+            List<double[]> out = new ArrayList<>(n);
+            if (n == maxSize) {
+                for (int i = 0; i < maxSize; i++) {
+                    int idx = (writeIndex + i) % maxSize;
+                    if (ring[idx] != null) out.add(ring[idx]);
+                }
+            } else {
+                for (int i = 0; i < writeIndex; i++) {
+                    if (ring[i] != null) out.add(ring[i]);
+                }
+            }
+            return out;
+        } finally {
+            writeLock.unlock();
+        }
+    }
+}

--- a/ai-sentinel-core/src/main/java/io/aisentinel/core/scoring/IsolationForestConfig.java
+++ b/ai-sentinel-core/src/main/java/io/aisentinel/core/scoring/IsolationForestConfig.java
@@ -1,0 +1,37 @@
+package io.aisentinel.core.scoring;
+
+/**
+ * Configuration for Isolation Forest scorer and training.
+ * Used by IsolationForestScorer; values typically come from SentinelProperties in the starter.
+ */
+public final class IsolationForestConfig {
+
+    private final double fallbackScore;
+    private final int minTrainingSamples;
+    private final int numTrees;
+    private final int maxDepth;
+    private final long randomSeed;
+    private final double sampleRate;
+
+    public IsolationForestConfig(double fallbackScore, int minTrainingSamples,
+                                  int numTrees, int maxDepth, long randomSeed, double sampleRate) {
+        this.fallbackScore = clamp(fallbackScore, 0.0, 1.0);
+        this.minTrainingSamples = Math.max(1, minTrainingSamples);
+        this.numTrees = Math.max(1, numTrees);
+        this.maxDepth = Math.max(1, maxDepth);
+        this.randomSeed = randomSeed;
+        this.sampleRate = clamp(sampleRate, 0.0, 1.0);
+    }
+
+    private static double clamp(double v, double lo, double hi) {
+        if (v < lo) return lo;
+        return Math.min(hi, v);
+    }
+
+    public double getFallbackScore() { return fallbackScore; }
+    public int getMinTrainingSamples() { return minTrainingSamples; }
+    public int getNumTrees() { return numTrees; }
+    public int getMaxDepth() { return maxDepth; }
+    public long getRandomSeed() { return randomSeed; }
+    public double getSampleRate() { return sampleRate; }
+}

--- a/ai-sentinel-core/src/main/java/io/aisentinel/core/scoring/IsolationForestModel.java
+++ b/ai-sentinel-core/src/main/java/io/aisentinel/core/scoring/IsolationForestModel.java
@@ -1,0 +1,89 @@
+package io.aisentinel.core.scoring;
+
+import java.util.List;
+
+/**
+ * Immutable Isolation Forest model. Built by {@link IsolationForestTrainer}.
+ * Score is in (0, 1]; higher = more anomalous. Caller clamps to [0, 1] if needed.
+ */
+final class IsolationForestModel {
+
+    private static final double EPS = 1e-10;
+
+    private final TreeNode[] trees;
+    private final int numSamples;
+    private final int dimension;
+
+    IsolationForestModel(TreeNode[] trees, int numSamples, int dimension) {
+        this.trees = trees;
+        this.numSamples = numSamples;
+        this.dimension = dimension;
+    }
+
+    /**
+     * Anomaly score: 2^(-E[h(x)]/c(n)). In (0, 1]; 1 = high anomaly.
+     * Returns value in (0, 1]; caller should clamp to [0, 1] and handle NaN.
+     */
+    double score(double[] x) {
+        if (x == null || x.length != dimension || trees.length == 0) return 0.5;
+        double sumPath = 0;
+        for (TreeNode root : trees) {
+            sumPath += pathLength(root, x, 0);
+        }
+        double avgPath = sumPath / trees.length;
+        double c = averagePathLength(numSamples);
+        double s = Math.pow(2, -avgPath / (c + EPS));
+        if (Double.isNaN(s) || Double.isInfinite(s) || s <= 0) return 0.5;
+        return Math.min(1.0, s);
+    }
+
+    private static double pathLength(TreeNode node, double[] x, int depth) {
+        if (node == null) return depth;
+        if (node.isLeaf) return depth + leafDepthCorrection(node.size);
+        int f = node.featureIndex;
+        if (f < 0 || f >= x.length) return depth;
+        if (x[f] < node.splitValue) return pathLength(node.left, x, depth + 1);
+        return pathLength(node.right, x, depth + 1);
+    }
+
+    /** c(n) = 2*H(n-1) - 2*(n-1)/n; approximate with 2*ln(n-1)+0.5772 - 2*(n-1)/n for n>=2 */
+    private static double averagePathLength(int n) {
+        if (n <= 1) return 1.0;
+        double ln = Math.log(n - 1 + EPS);
+        return 2 * (ln + 0.5772156649) - 2.0 * (n - 1) / n;
+    }
+
+    /** Leaf with size s gets depth += 2*(ln(s-1)+0.5772) - 2*(s-1)/s for s>1 */
+    private static double leafDepthCorrection(int size) {
+        if (size <= 1) return 0;
+        double ln = Math.log(size - 1 + EPS);
+        return 2 * (ln + 0.5772156649) - 2.0 * (size - 1) / size;
+    }
+
+    static final class TreeNode {
+        final int featureIndex;
+        final double splitValue;
+        final TreeNode left;
+        final TreeNode right;
+        final boolean isLeaf;
+        final int size;
+
+        TreeNode(int featureIndex, double splitValue, TreeNode left, TreeNode right) {
+            this.featureIndex = featureIndex;
+            this.splitValue = splitValue;
+            this.left = left;
+            this.right = right;
+            this.isLeaf = false;
+            this.size = 0;
+        }
+
+        TreeNode(int size) {
+            this.featureIndex = -1;
+            this.splitValue = 0;
+            this.left = null;
+            this.right = null;
+            this.isLeaf = true;
+            this.size = size;
+        }
+    }
+}

--- a/ai-sentinel-core/src/main/java/io/aisentinel/core/scoring/IsolationForestScorer.java
+++ b/ai-sentinel-core/src/main/java/io/aisentinel/core/scoring/IsolationForestScorer.java
@@ -1,20 +1,110 @@
 package io.aisentinel.core.scoring;
 
 import io.aisentinel.core.model.RequestFeatures;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
 
 /**
- * Isolation Forest-based anomaly scorer (stub in v1).
- * Disabled by default; enable via ai.sentinel.isolation-forest.enabled=true.
+ * Isolation Forest-based anomaly scorer. Uses a bounded training buffer and
+ * async retrain to produce scores in [0,1]. When no model is loaded, returns
+ * configurable fallback score so CompositeScorer effectively relies on StatisticalScorer.
  */
 public final class IsolationForestScorer implements AnomalyScorer {
 
+    private static final Logger log = LoggerFactory.getLogger(IsolationForestScorer.class);
+
+    private final BoundedTrainingBuffer buffer;
+    private final IsolationForestConfig config;
+    private final IsolationForestTrainer trainer;
+
+    private volatile IsolationForestModel model;
+    private final AtomicLong modelVersion = new AtomicLong(0);
+    private volatile long lastRetrainTimeMillis;
+    private final AtomicLong retrainFailureCount = new AtomicLong(0);
+    private volatile long lastRetrainFailureTimeMillis;
+
+    public IsolationForestScorer(BoundedTrainingBuffer buffer, IsolationForestConfig config) {
+        this.buffer = buffer;
+        this.config = config;
+        this.trainer = new IsolationForestTrainer(
+            config.getNumTrees(),
+            config.getMaxDepth(),
+            config.getRandomSeed()
+        );
+    }
+
     @Override
     public double score(RequestFeatures features) {
-        return 0.0;
+        IsolationForestModel m = model;
+        if (m == null) return config.getFallbackScore();
+        double[] x = features.toArray();
+        double s = m.score(x);
+        if (Double.isNaN(s) || s < 0) return config.getFallbackScore();
+        return Math.min(1.0, Math.max(0.0, s));
     }
 
     @Override
     public void update(RequestFeatures features) {
-        // no-op in stub
+        if (config.getSampleRate() <= 0) return;
+        IsolationForestModel m = model;
+        if (m != null) {
+            double s = score(features);
+            if (s > 0.7) return;
+        }
+        if (config.getSampleRate() >= 1.0 || ThreadLocalRandomHolder.nextDouble() < config.getSampleRate()) {
+            buffer.add(features.toArray());
+        }
+    }
+
+    /**
+     * Trains a new model from the buffer and atomically swaps it in.
+     * Safe to call from a background scheduler. Training failures do not affect the current model.
+     */
+    public void retrain() {
+        List<double[]> samples = buffer.getSnapshotForTraining();
+        if (samples.size() < config.getMinTrainingSamples()) return;
+        long startMs = System.currentTimeMillis();
+        try {
+            IsolationForestModel newModel = trainer.train(samples);
+            if (newModel != null) {
+                model = newModel;
+                long v = modelVersion.incrementAndGet();
+                lastRetrainTimeMillis = System.currentTimeMillis();
+                long durationMs = lastRetrainTimeMillis - startMs;
+                log.info("IF retrain v{} completed in {}ms using {} samples", v, durationMs, samples.size());
+            }
+        } catch (Exception e) {
+            retrainFailureCount.incrementAndGet();
+            lastRetrainFailureTimeMillis = System.currentTimeMillis();
+            log.warn("Isolation Forest retrain failed (request path unaffected): {}", e.getMessage());
+        }
+    }
+
+    public long getLastRetrainTimeMillis() { return lastRetrainTimeMillis; }
+    public long getModelVersion() { return modelVersion.get(); }
+    public int getBufferedSampleCount() { return buffer.size(); }
+    public boolean isModelLoaded() { return model != null; }
+
+    /**
+     * Age of the current model in milliseconds, or -1 if no model is loaded.
+     */
+    public long getModelAgeMillis() {
+        if (model == null) return -1L;
+        long t = lastRetrainTimeMillis;
+        return t <= 0 ? -1L : (System.currentTimeMillis() - t);
+    }
+
+    public long getRetrainFailureCount() { return retrainFailureCount.get(); }
+    public long getLastRetrainFailureTimeMillis() { return lastRetrainFailureTimeMillis; }
+
+    /** ThreadLocalRandom for sampling without allocating per request. */
+    private static final class ThreadLocalRandomHolder {
+        private static final java.util.concurrent.ThreadLocalRandom get() {
+            return java.util.concurrent.ThreadLocalRandom.current();
+        }
+        static double nextDouble() { return get().nextDouble(); }
     }
 }

--- a/ai-sentinel-core/src/main/java/io/aisentinel/core/scoring/IsolationForestTrainer.java
+++ b/ai-sentinel-core/src/main/java/io/aisentinel/core/scoring/IsolationForestTrainer.java
@@ -1,0 +1,67 @@
+package io.aisentinel.core.scoring;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+/**
+ * Builds an IsolationForestModel from a list of feature vectors using a fixed seed for determinism.
+ */
+final class IsolationForestTrainer {
+
+    private final int numTrees;
+    private final int maxDepth;
+    private final long randomSeed;
+
+    IsolationForestTrainer(int numTrees, int maxDepth, long randomSeed) {
+        this.numTrees = Math.max(1, numTrees);
+        this.maxDepth = Math.max(1, maxDepth);
+        this.randomSeed = randomSeed;
+    }
+
+    /**
+     * Builds a model from the given samples. Returns null if samples are empty or dimension mismatch.
+     */
+    IsolationForestModel train(List<double[]> samples) {
+        if (samples == null || samples.isEmpty()) return null;
+        int dim = samples.get(0).length;
+        for (double[] row : samples) {
+            if (row.length != dim) return null;
+        }
+        int n = samples.size();
+        IsolationForestModel.TreeNode[] trees = new IsolationForestModel.TreeNode[numTrees];
+        for (int t = 0; t < numTrees; t++) {
+            Random rng = new Random(randomSeed + t);
+            trees[t] = buildTree(samples, 0, dim, rng);
+        }
+        return new IsolationForestModel(trees, n, dim);
+    }
+
+    private IsolationForestModel.TreeNode buildTree(List<double[]> data, int depth, int dimension, Random rng) {
+        if (data.isEmpty()) return new IsolationForestModel.TreeNode(0);
+        if (data.size() == 1 || depth >= maxDepth) return new IsolationForestModel.TreeNode(data.size());
+
+        int featureIndex = rng.nextInt(dimension);
+        double min = Double.POSITIVE_INFINITY;
+        double max = Double.NEGATIVE_INFINITY;
+        for (double[] row : data) {
+            double v = row[featureIndex];
+            if (v < min) min = v;
+            if (v > max) max = v;
+        }
+        if (min >= max) return new IsolationForestModel.TreeNode(data.size());
+
+        double splitValue = min + (max - min) * (0.2 + 0.6 * rng.nextDouble());
+        List<double[]> left = new ArrayList<>();
+        List<double[]> right = new ArrayList<>();
+        for (double[] row : data) {
+            if (row[featureIndex] < splitValue) left.add(row);
+            else right.add(row);
+        }
+        if (left.isEmpty() || right.isEmpty()) return new IsolationForestModel.TreeNode(data.size());
+
+        IsolationForestModel.TreeNode leftNode = buildTree(left, depth + 1, dimension, rng);
+        IsolationForestModel.TreeNode rightNode = buildTree(right, depth + 1, dimension, rng);
+        return new IsolationForestModel.TreeNode(featureIndex, splitValue, leftNode, rightNode);
+    }
+}

--- a/ai-sentinel-core/src/test/java/io/aisentinel/core/scoring/BoundedTrainingBufferTest.java
+++ b/ai-sentinel-core/src/test/java/io/aisentinel/core/scoring/BoundedTrainingBufferTest.java
@@ -1,0 +1,72 @@
+package io.aisentinel.core.scoring;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class BoundedTrainingBufferTest {
+
+    @Test
+    void bufferBoundedWhenOverMaxSize() {
+        var buffer = new BoundedTrainingBuffer(3);
+        buffer.add(new double[]{1, 2, 3});
+        buffer.add(new double[]{4, 5, 6});
+        buffer.add(new double[]{7, 8, 9});
+        assertThat(buffer.size()).isEqualTo(3);
+        buffer.add(new double[]{10, 11, 12});
+        buffer.add(new double[]{13, 14, 15});
+        assertThat(buffer.size()).isEqualTo(3);
+        List<double[]> snap = buffer.getSnapshotForTraining();
+        assertThat(snap).hasSize(3);
+    }
+
+    @Test
+    void snapshotContainsStoredVectors() {
+        var buffer = new BoundedTrainingBuffer(10);
+        buffer.add(new double[]{1.0, 2.0});
+        buffer.add(new double[]{3.0, 4.0});
+        List<double[]> snap = buffer.getSnapshotForTraining();
+        assertThat(snap).hasSize(2);
+        assertThat(snap.get(0)).containsExactly(1.0, 2.0);
+        assertThat(snap.get(1)).containsExactly(3.0, 4.0);
+    }
+
+    @Test
+    void concurrentAddsDoNotExceedMaxSize() throws InterruptedException {
+        var buffer = new BoundedTrainingBuffer(100);
+        int threads = 4;
+        int addsPerThread = 500;
+        CountDownLatch start = new CountDownLatch(1);
+        CountDownLatch done = new CountDownLatch(threads);
+        for (int t = 0; t < threads; t++) {
+            new Thread(() -> {
+                try {
+                    start.await();
+                    for (int i = 0; i < addsPerThread; i++) {
+                        buffer.add(new double[]{i, i * 2});
+                    }
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                } finally {
+                    done.countDown();
+                }
+            }).start();
+        }
+        start.countDown();
+        done.await();
+        assertThat(buffer.size()).isLessThanOrEqualTo(100);
+        assertThat(buffer.getSnapshotForTraining()).hasSize(buffer.size());
+    }
+
+    @Test
+    void addIgnoresNullOrEmpty() {
+        var buffer = new BoundedTrainingBuffer(5);
+        buffer.add(null);
+        buffer.add(new double[0]);
+        assertThat(buffer.size()).isEqualTo(0);
+    }
+}

--- a/ai-sentinel-core/src/test/java/io/aisentinel/core/scoring/IsolationForestScorerTest.java
+++ b/ai-sentinel-core/src/test/java/io/aisentinel/core/scoring/IsolationForestScorerTest.java
@@ -1,0 +1,101 @@
+package io.aisentinel.core.scoring;
+
+import io.aisentinel.core.model.RequestFeatures;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class IsolationForestScorerTest {
+
+    private static RequestFeatures features(double... values) {
+        if (values.length < 7) throw new IllegalArgumentException("need 7 values");
+        return RequestFeatures.builder()
+            .identityHash("id")
+            .endpoint("/api")
+            .timestampMillis(0)
+            .requestsPerWindow(values[0])
+            .endpointEntropy(values[1])
+            .tokenAgeSeconds(values[2])
+            .parameterCount((int) values[3])
+            .payloadSizeBytes((long) values[4])
+            .headerFingerprintHash((long) values[5])
+            .ipBucket((int) values[6])
+            .build();
+    }
+
+    @Test
+    void scoreReturnsFallbackWhenNoModel() {
+        var buffer = new BoundedTrainingBuffer(1000);
+        var config = new IsolationForestConfig(0.5, 50, 10, 5, 42L, 1.0);
+        var scorer = new IsolationForestScorer(buffer, config);
+        assertThat(scorer.isModelLoaded()).isFalse();
+        assertThat(scorer.score(features(1, 0, 60, 0, 100, 0, 0))).isEqualTo(0.5);
+    }
+
+    @Test
+    void scoreInRangeAfterTraining() {
+        var buffer = new BoundedTrainingBuffer(500);
+        var config = new IsolationForestConfig(0.5, 50, 20, 8, 42L, 1.0);
+        var scorer = new IsolationForestScorer(buffer, config);
+        for (int i = 0; i < 100; i++) {
+            buffer.add(new double[]{i % 10, 0.5, 60, 2, 100 + i, 0, 0});
+        }
+        scorer.retrain();
+        assertThat(scorer.isModelLoaded()).isTrue();
+        double s = scorer.score(features(5, 0.5, 60, 2, 150, 0, 0));
+        assertThat(s).isBetween(0.0, 1.0);
+    }
+
+    @Test
+    void retrainFailureDoesNotBreakInference() {
+        var buffer = new BoundedTrainingBuffer(10);
+        var config = new IsolationForestConfig(0.4, 100, 5, 5, 42L, 1.0);
+        var scorer = new IsolationForestScorer(buffer, config);
+        for (int i = 0; i < 5; i++) buffer.add(new double[]{1, 2, 3, 4, 5, 6, 7});
+        scorer.retrain();
+        assertThat(scorer.isModelLoaded()).isFalse();
+        assertThat(scorer.score(features(1, 2, 3, 4, 5, 6, 7))).isEqualTo(0.4);
+        scorer.retrain();
+        assertThat(scorer.score(features(1, 2, 3, 4, 5, 6, 7))).isEqualTo(0.4);
+    }
+
+    @Test
+    void modelSwapIsAtomicAndVisible() throws InterruptedException {
+        var buffer = new BoundedTrainingBuffer(200);
+        var config = new IsolationForestConfig(0.5, 30, 10, 6, 123L, 1.0);
+        var scorer = new IsolationForestScorer(buffer, config);
+        for (int i = 0; i < 50; i++) {
+            buffer.add(new double[]{i, i * 0.1, 60, 1, 100, 0, 0});
+        }
+        scorer.retrain();
+        assertThat(scorer.isModelLoaded()).isTrue();
+        long v1 = scorer.getModelVersion();
+        for (int i = 0; i < 50; i++) {
+            buffer.add(new double[]{i + 50, 0.5, 60, 1, 200, 0, 0});
+        }
+        scorer.retrain();
+        long v2 = scorer.getModelVersion();
+        assertThat(v2).isGreaterThanOrEqualTo(v1);
+        double score = scorer.score(features(25, 0.5, 60, 1, 150, 0, 0));
+        assertThat(score).isBetween(0.0, 1.0);
+    }
+
+    @Test
+    void metadataExposed() {
+        var buffer = new BoundedTrainingBuffer(100);
+        var config = new IsolationForestConfig(0.5, 10, 5, 5, 42L, 1.0);
+        var scorer = new IsolationForestScorer(buffer, config);
+        assertThat(scorer.getBufferedSampleCount()).isEqualTo(0);
+        assertThat(scorer.getLastRetrainTimeMillis()).isEqualTo(0);
+        assertThat(scorer.getModelAgeMillis()).isEqualTo(-1L);
+        assertThat(scorer.getRetrainFailureCount()).isEqualTo(0L);
+        for (int i = 0; i < 15; i++) buffer.add(new double[]{1, 2, 3, 4, 5, 6, 7});
+        assertThat(scorer.getBufferedSampleCount()).isEqualTo(15);
+        scorer.retrain();
+        assertThat(scorer.isModelLoaded()).isTrue();
+        assertThat(scorer.getModelVersion()).isGreaterThan(0);
+        assertThat(scorer.getLastRetrainTimeMillis()).isGreaterThan(0);
+        assertThat(scorer.getModelAgeMillis()).isGreaterThanOrEqualTo(0L);
+        assertThat(scorer.getRetrainFailureCount()).isEqualTo(0L);
+    }
+}

--- a/ai-sentinel-demo/src/main/resources/application-stage2.yaml
+++ b/ai-sentinel-demo/src/main/resources/application-stage2.yaml
@@ -1,0 +1,16 @@
+# Stage 2 validation profile: local-friendly Isolation Forest config
+# Run with: mvn -pl ai-sentinel-demo spring-boot:run -Dspring-boot.run.profiles=stage2
+ai:
+  sentinel:
+    enabled: true
+    mode: MONITOR
+    isolation-forest:
+      enabled: true
+      min-training-samples: 50
+      retrain-interval: 15s
+      sample-rate: 1.0
+      training-buffer-size: 500
+    # Stage 2.3 validation: log every score for normal vs attack comparison
+    telemetry:
+      log-verbosity: FULL
+      log-score-threshold: 0

--- a/ai-sentinel-spring-boot-starter/src/main/java/io/aisentinel/autoconfigure/actuator/SentinelActuatorEndpoint.java
+++ b/ai-sentinel-spring-boot-starter/src/main/java/io/aisentinel/autoconfigure/actuator/SentinelActuatorEndpoint.java
@@ -2,20 +2,29 @@ package io.aisentinel.autoconfigure.actuator;
 
 import io.aisentinel.autoconfigure.config.SentinelProperties;
 import io.aisentinel.core.enforcement.CompositeEnforcementHandler;
-import lombok.RequiredArgsConstructor;
+import io.aisentinel.core.scoring.IsolationForestScorer;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.actuate.endpoint.annotation.Endpoint;
 import org.springframework.boot.actuate.endpoint.annotation.ReadOperation;
+
 import java.util.LinkedHashMap;
 import java.util.Map;
 
 @Slf4j
 @Endpoint(id = "sentinel")
-@RequiredArgsConstructor
 public class SentinelActuatorEndpoint {
 
     private final SentinelProperties props;
     private final CompositeEnforcementHandler enforcementHandlerImpl;
+    private final IsolationForestScorer isolationForestScorer;
+
+    public SentinelActuatorEndpoint(SentinelProperties props,
+                                    CompositeEnforcementHandler enforcementHandlerImpl,
+                                    IsolationForestScorer isolationForestScorer) {
+        this.props = props;
+        this.enforcementHandlerImpl = enforcementHandlerImpl;
+        this.isolationForestScorer = isolationForestScorer;
+    }
 
     @ReadOperation
     public Map<String, Object> info() {
@@ -25,6 +34,15 @@ public class SentinelActuatorEndpoint {
         map.put("mode", props.getMode().name());
         map.put("isolationForestEnabled", props.getIsolationForest().isEnabled());
         map.put("quarantineCount", enforcementHandlerImpl.getQuarantineCount());
+        if (props.getIsolationForest().isEnabled() && isolationForestScorer != null) {
+            map.put("isolationForestModelLoaded", isolationForestScorer.isModelLoaded());
+            map.put("isolationForestBufferedSampleCount", isolationForestScorer.getBufferedSampleCount());
+            map.put("isolationForestModelVersion", isolationForestScorer.getModelVersion());
+            map.put("isolationForestLastRetrainTimeMillis", isolationForestScorer.getLastRetrainTimeMillis());
+            map.put("isolationForestModelAgeMillis", isolationForestScorer.getModelAgeMillis());
+            map.put("isolationForestRetrainFailureCount", isolationForestScorer.getRetrainFailureCount());
+            map.put("isolationForestLastRetrainFailureTimeMillis", isolationForestScorer.getLastRetrainFailureTimeMillis());
+        }
         return map;
     }
 }

--- a/ai-sentinel-spring-boot-starter/src/main/java/io/aisentinel/autoconfigure/actuator/SentinelEndpointAutoConfiguration.java
+++ b/ai-sentinel-spring-boot-starter/src/main/java/io/aisentinel/autoconfigure/actuator/SentinelEndpointAutoConfiguration.java
@@ -2,30 +2,34 @@ package io.aisentinel.autoconfigure.actuator;
 
 import io.aisentinel.autoconfigure.config.SentinelProperties;
 import io.aisentinel.core.enforcement.CompositeEnforcementHandler;
+import io.aisentinel.core.scoring.IsolationForestScorer;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.actuate.autoconfigure.endpoint.web.WebEndpointAutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import io.aisentinel.autoconfigure.config.SentinelAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
 import org.springframework.context.annotation.Bean;
+import org.springframework.beans.factory.ObjectProvider;
 
 /**
  * Registers the Sentinel actuator endpoint.
  * Loads after WebEndpointAutoConfiguration so the endpoint infrastructure is ready.
  */
 @Slf4j
-@AutoConfiguration(after = WebEndpointAutoConfiguration.class)
+@AutoConfiguration(after = { WebEndpointAutoConfiguration.class, SentinelAutoConfiguration.class })
 @ConditionalOnWebApplication
-@ConditionalOnBean(SentinelProperties.class)
+@ConditionalOnBean(CompositeEnforcementHandler.class)
 @ConditionalOnClass(name = "org.springframework.boot.actuate.endpoint.annotation.Endpoint")
 public class SentinelEndpointAutoConfiguration {
 
     @Bean
     @ConditionalOnBean(CompositeEnforcementHandler.class)
     public SentinelActuatorEndpoint sentinelActuatorEndpoint(SentinelProperties props,
-                                                            CompositeEnforcementHandler enforcementHandlerImpl) {
+                                                            CompositeEnforcementHandler enforcementHandlerImpl,
+                                                            ObjectProvider<IsolationForestScorer> isolationForestScorerProvider) {
         log.debug("Registering Sentinel actuator endpoint");
-        return new SentinelActuatorEndpoint(props, enforcementHandlerImpl);
+        return new SentinelActuatorEndpoint(props, enforcementHandlerImpl, isolationForestScorerProvider.getIfAvailable());
     }
 }

--- a/ai-sentinel-spring-boot-starter/src/main/java/io/aisentinel/autoconfigure/config/IsolationForestRetrainScheduler.java
+++ b/ai-sentinel-spring-boot-starter/src/main/java/io/aisentinel/autoconfigure/config/IsolationForestRetrainScheduler.java
@@ -1,0 +1,64 @@
+package io.aisentinel.autoconfigure.config;
+
+import io.aisentinel.core.scoring.IsolationForestScorer;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.DisposableBean;
+
+import jakarta.annotation.PostConstruct;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Schedules periodic retraining of Isolation Forest when enabled.
+ * Runs in a single background thread; does not block the request path.
+ */
+@Slf4j
+public class IsolationForestRetrainScheduler implements DisposableBean {
+
+    private final IsolationForestScorer scorer;
+    private final SentinelProperties props;
+    private ScheduledExecutorService executor;
+
+    public IsolationForestRetrainScheduler(IsolationForestScorer scorer, SentinelProperties props) {
+        this.scorer = scorer;
+        this.props = props;
+    }
+
+    @PostConstruct
+    public void start() {
+        long intervalMs = props.getIsolationForest().getRetrainInterval() != null
+            ? props.getIsolationForest().getRetrainInterval().toMillis()
+            : 300_000L;
+        intervalMs = Math.max(60_000L, intervalMs);
+        long initialDelayMs = Math.min(intervalMs, 30_000L);
+        executor = Executors.newSingleThreadScheduledExecutor(r -> {
+            Thread t = new Thread(r, "aisentinel-if-retrain");
+            t.setDaemon(true);
+            return t;
+        });
+        executor.scheduleAtFixedRate(this::runRetrain, initialDelayMs, intervalMs, TimeUnit.MILLISECONDS);
+        log.info("Isolation Forest retrain scheduled every {} ms (first run in {} ms)", intervalMs, initialDelayMs);
+    }
+
+    private void runRetrain() {
+        try {
+            scorer.retrain();
+        } catch (Exception e) {
+            log.warn("Isolation Forest retrain failed (request path unaffected): {}", e.getMessage());
+        }
+    }
+
+    @Override
+    public void destroy() {
+        if (executor != null) {
+            executor.shutdown();
+            try {
+                if (!executor.awaitTermination(5, TimeUnit.SECONDS)) executor.shutdownNow();
+            } catch (InterruptedException e) {
+                executor.shutdownNow();
+                Thread.currentThread().interrupt();
+            }
+        }
+    }
+}

--- a/ai-sentinel-spring-boot-starter/src/main/java/io/aisentinel/autoconfigure/config/SentinelAutoConfiguration.java
+++ b/ai-sentinel-spring-boot-starter/src/main/java/io/aisentinel/autoconfigure/config/SentinelAutoConfiguration.java
@@ -8,7 +8,9 @@ import io.aisentinel.core.feature.DefaultFeatureExtractor;
 import io.aisentinel.core.feature.FeatureExtractor;
 import io.aisentinel.core.policy.PolicyEngine;
 import io.aisentinel.core.policy.ThresholdPolicyEngine;
+import io.aisentinel.core.scoring.BoundedTrainingBuffer;
 import io.aisentinel.core.scoring.CompositeScorer;
+import io.aisentinel.core.scoring.IsolationForestConfig;
 import io.aisentinel.core.scoring.IsolationForestScorer;
 import io.aisentinel.core.scoring.StatisticalScorer;
 import io.aisentinel.core.store.BaselineStore;
@@ -25,6 +27,13 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplicat
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 
 @Slf4j
 @AutoConfiguration
@@ -60,8 +69,34 @@ public class SentinelAutoConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
-    public IsolationForestScorer isolationForestScorer() {
-        return new IsolationForestScorer();
+    public BoundedTrainingBuffer isolationForestTrainingBuffer(SentinelProperties props) {
+        int size = props.getIsolationForest().getTrainingBufferSize();
+        size = size <= 0 ? 10_000 : size;
+        return new BoundedTrainingBuffer(size);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public IsolationForestConfig isolationForestConfig(SentinelProperties props) {
+        var ifProps = props.getIsolationForest();
+        double fallback = ifProps.getFallbackScore() >= 0 ? Math.min(1.0, ifProps.getFallbackScore()) : 0.5;
+        int numTrees = ifProps.getNumTrees() > 0 ? ifProps.getNumTrees() : 100;
+        int maxDepth = ifProps.getMaxDepth() > 0 ? ifProps.getMaxDepth() : 10;
+        return new IsolationForestConfig(
+            fallback,
+            Math.max(1, ifProps.getMinTrainingSamples()),
+            numTrees,
+            maxDepth,
+            ifProps.getRandomSeed(),
+            ifProps.getSampleRate() < 0 ? 0.1 : Math.min(1.0, ifProps.getSampleRate())
+        );
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public IsolationForestScorer isolationForestScorer(BoundedTrainingBuffer isolationForestTrainingBuffer,
+                                                      IsolationForestConfig isolationForestConfig) {
+        return new IsolationForestScorer(isolationForestTrainingBuffer, isolationForestConfig);
     }
 
     @Bean
@@ -72,10 +107,20 @@ public class SentinelAutoConfiguration {
         var composite = new CompositeScorer();
         composite.addScorer(statisticalScorer, 1.0);
         if (props.getIsolationForest().isEnabled()) {
-            log.debug("Adding IsolationForestScorer with weight 0.5");
-            composite.addScorer(isolationForestScorer, 0.5);
+            double weight = props.getIsolationForest().getScoreWeight();
+            if (weight <= 0) weight = 0.5;
+            log.debug("Adding IsolationForestScorer with weight {}", weight);
+            composite.addScorer(isolationForestScorer, weight);
         }
         return composite;
+    }
+
+    @Bean
+    @ConditionalOnProperty(name = "ai.sentinel.isolation-forest.enabled", havingValue = "true")
+    @ConditionalOnBean(IsolationForestScorer.class)
+    public IsolationForestRetrainScheduler isolationForestRetrainScheduler(IsolationForestScorer isolationForestScorer,
+                                                                          SentinelProperties props) {
+        return new IsolationForestRetrainScheduler(isolationForestScorer, props);
     }
 
     @Bean

--- a/ai-sentinel-spring-boot-starter/src/main/java/io/aisentinel/autoconfigure/config/SentinelProperties.java
+++ b/ai-sentinel-spring-boot-starter/src/main/java/io/aisentinel/autoconfigure/config/SentinelProperties.java
@@ -4,7 +4,6 @@ import lombok.Data;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 import java.time.Duration;
-import java.util.ArrayList;
 import java.util.List;
 
 @Data
@@ -49,5 +48,18 @@ public class SentinelProperties {
     @Data
     public static class IsolationForest {
         private boolean enabled = false;
+        private int trainingBufferSize = 10_000;
+        private int minTrainingSamples = 100;
+        private Duration retrainInterval = Duration.ofMinutes(5);
+        private long randomSeed = 42L;
+        private double scoreWeight = 0.5;
+        /** Fraction of requests to add to training buffer (0.0–1.0). Default 0.1 */
+        private double sampleRate = 0.1;
+        /** Score returned when no model is loaded (fallback). Default 0.5 */
+        private double fallbackScore = 0.5;
+        /** Number of trees in the Isolation Forest. Default 100 */
+        private int numTrees = 100;
+        /** Maximum tree depth. Default 10 */
+        private int maxDepth = 10;
     }
 }

--- a/ai-sentinel-spring-boot-starter/src/test/java/io/aisentinel/autoconfigure/actuator/SentinelActuatorEndpointTest.java
+++ b/ai-sentinel-spring-boot-starter/src/test/java/io/aisentinel/autoconfigure/actuator/SentinelActuatorEndpointTest.java
@@ -2,6 +2,9 @@ package io.aisentinel.autoconfigure.actuator;
 
 import io.aisentinel.autoconfigure.config.SentinelProperties;
 import io.aisentinel.core.enforcement.CompositeEnforcementHandler;
+import io.aisentinel.core.scoring.BoundedTrainingBuffer;
+import io.aisentinel.core.scoring.IsolationForestConfig;
+import io.aisentinel.core.scoring.IsolationForestScorer;
 import io.aisentinel.core.telemetry.TelemetryEmitter;
 import org.junit.jupiter.api.Test;
 
@@ -19,7 +22,7 @@ class SentinelActuatorEndpointTest {
     @Test
     void infoReturnsExpectedStructure() {
         SentinelProperties props = new SentinelProperties();
-        SentinelActuatorEndpoint endpoint = new SentinelActuatorEndpoint(props, compositeHandler());
+        SentinelActuatorEndpoint endpoint = new SentinelActuatorEndpoint(props, compositeHandler(), null);
 
         Map<String, Object> info = endpoint.info();
 
@@ -36,7 +39,7 @@ class SentinelActuatorEndpointTest {
         props.setEnabled(false);
         props.setMode(SentinelProperties.Mode.MONITOR);
         props.getIsolationForest().setEnabled(true);
-        SentinelActuatorEndpoint endpoint = new SentinelActuatorEndpoint(props, compositeHandler());
+        SentinelActuatorEndpoint endpoint = new SentinelActuatorEndpoint(props, compositeHandler(), null);
 
         Map<String, Object> info = endpoint.info();
 
@@ -44,5 +47,26 @@ class SentinelActuatorEndpointTest {
         assertThat(info.get("mode")).isEqualTo("MONITOR");
         assertThat(info.get("isolationForestEnabled")).isEqualTo(true);
         assertThat(info.get("quarantineCount")).isEqualTo(0);
+    }
+
+    @Test
+    void infoIncludesIsolationForestMetadataWhenEnabledAndScorerProvided() {
+        SentinelProperties props = new SentinelProperties();
+        props.getIsolationForest().setEnabled(true);
+        var buffer = new BoundedTrainingBuffer(100);
+        var config = new IsolationForestConfig(0.5, 10, 5, 5, 42L, 0.1);
+        IsolationForestScorer ifScorer = new IsolationForestScorer(buffer, config);
+        SentinelActuatorEndpoint endpoint = new SentinelActuatorEndpoint(props, compositeHandler(), ifScorer);
+
+        Map<String, Object> info = endpoint.info();
+
+        assertThat(info).containsKeys("isolationForestModelLoaded", "isolationForestBufferedSampleCount",
+            "isolationForestModelVersion", "isolationForestLastRetrainTimeMillis",
+            "isolationForestModelAgeMillis", "isolationForestRetrainFailureCount",
+            "isolationForestLastRetrainFailureTimeMillis");
+        assertThat(info.get("isolationForestModelLoaded")).isEqualTo(false);
+        assertThat(info.get("isolationForestBufferedSampleCount")).isEqualTo(0);
+        assertThat(info.get("isolationForestModelAgeMillis")).isEqualTo(-1L);
+        assertThat(info.get("isolationForestRetrainFailureCount")).isEqualTo(0L);
     }
 }

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,105 @@
+# Developer scripts
+
+## Stage 2: Isolation Forest training monitor
+
+`train_monitor.py` generates traffic to the demo app and polls `/actuator/sentinel` until the Isolation Forest model is trained and loaded. Use it to verify Stage 2 behavior locally.
+
+**Requirements:** Python 3.7+ (standard library only).
+
+### 1. Start the demo with Isolation Forest enabled
+
+```bash
+# From repo root
+mvn -pl ai-sentinel-demo spring-boot:run
+```
+
+In `ai-sentinel-demo/src/main/resources/application.yaml` (or a profile), set:
+
+```yaml
+ai:
+  sentinel:
+    isolation-forest:
+      enabled: true
+      min-training-samples: 100   # lower for faster test (e.g. 50)
+      retrain-interval: 1m
+```
+
+Restart the demo after changing config.
+
+### 2. Run the script
+
+```bash
+# Defaults: http://localhost:8080, 500 requests, poll every 3s
+python scripts/train_monitor.py
+```
+
+**Options:**
+
+| Flag | Default | Description |
+|------|--------|-------------|
+| `--base-url` | `http://localhost:8080` | Base URL of the app |
+| `--traffic-endpoint` | `/api/hello` | Path to call for traffic |
+| `--total-requests` | `500` | Number of requests to send |
+| `--concurrency` | `4` | Concurrent workers |
+| `--poll-interval` | `3.0` | Seconds between actuator polls |
+| `--request-delay-ms` | `10` | Delay between requests per worker (ms) |
+
+**Examples:**
+
+```bash
+# More traffic, poll every 2 seconds
+python scripts/train_monitor.py --total-requests 1000 --poll-interval 2
+
+# Different port
+python scripts/train_monitor.py --base-url http://localhost:9090
+
+# Less delay for faster fill of the buffer
+python scripts/train_monitor.py --request-delay-ms 0 --total-requests 300
+```
+
+The script exits with code **0** when `isolationForestModelLoaded` is true and `isolationForestModelVersion >= 1`, otherwise **1**. Connection errors are reported to stderr; the script fails fast if the actuator is unreachable at startup.
+
+---
+
+## Traffic simulator
+
+`traffic_simulator.py` generates configurable traffic patterns to train and evaluate the Isolation Forest model. It randomizes headers, query parameters, and payload sizes.
+
+**Requirements:** Python 3.7+ (standard library only).
+
+### Modes
+
+| Mode | Description |
+|------|--------------|
+| **normal** | Steady request rate; mostly GET with small/empty body; random User-Agent, Accept, optional query params. |
+| **burst** | Short bursts at ~2× RPS then pause; simulates traffic spikes. |
+| **attack** | Diverse endpoints, wider payload size range (including large bodies), more header variation. |
+
+### Usage
+
+```bash
+# Steady traffic for 60s at 10 RPS (default)
+python scripts/traffic_simulator.py --mode normal
+
+# Burst pattern, 30s
+python scripts/traffic_simulator.py --mode burst --duration 30 --requests-per-second 15
+
+# Attack-style (diverse endpoints + payloads)
+python scripts/traffic_simulator.py --mode attack --duration 45 --concurrency 8
+```
+
+### Options
+
+| Flag | Default | Description |
+|------|--------|-------------|
+| `--mode` | `normal` | `normal`, `burst`, or `attack` |
+| `--base-url` | `http://localhost:8080` | Base URL of the app |
+| `--duration` | `60.0` | Run duration in seconds |
+| `--requests-per-second` | `10.0` | Target RPS (burst uses higher rate during spikes) |
+| `--concurrency` | `4` | Number of concurrent workers |
+| `--endpoints` | `/api/hello,/api/items,...` | Comma-separated paths |
+| `--timeout` | `10.0` | Request timeout in seconds |
+
+### Output
+
+Prints requests sent, errors, total, elapsed time, actual RPS, and latency (min, avg, max, p50, p99 in ms). Exit code **1** if any request failed.

--- a/scripts/traffic_simulator.py
+++ b/scripts/traffic_simulator.py
@@ -1,0 +1,303 @@
+#!/usr/bin/env python3
+"""
+AI-Sentinel traffic simulation utility.
+
+Generates configurable request patterns (normal, burst, attack) to train and
+evaluate the Isolation Forest model. Uses only the Python standard library.
+
+Usage:
+  python scripts/traffic_simulator.py --mode normal --duration 60
+  python scripts/traffic_simulator.py --mode burst --requests-per-second 20
+  python scripts/traffic_simulator.py --mode attack --duration 30 --concurrency 8
+"""
+
+import argparse
+import random
+import sys
+import time
+import urllib.error
+import urllib.request
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from threading import Lock
+from urllib.parse import urlencode
+
+# Default endpoints for diverse/attack mode
+DEFAULT_ENDPOINTS = ["/api/hello", "/api/items", "/api/users", "/api/health"]
+
+USER_AGENTS = [
+    "Mozilla/5.0 (Windows NT 10.0; rv:91.0) Gecko/20100101 Firefox/91.0",
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36",
+    "curl/7.68.0",
+    "Python-urllib/3.9",
+    "PostmanRuntime/7.28.4",
+]
+
+ACCEPT_HEADERS = [
+    "application/json",
+    "text/plain",
+    "application/json, text/plain, */*",
+    "*/*",
+]
+
+
+class Stats:
+    def __init__(self):
+        self.lock = Lock()
+        self.sent = 0
+        self.errors = 0
+        self.latencies = []
+
+    def record_success(self, latency_sec):
+        with self.lock:
+            self.sent += 1
+            self.latencies.append(latency_sec)
+
+    def record_error(self):
+        with self.lock:
+            self.errors += 1
+
+    def summary(self):
+        with self.lock:
+            total = self.sent + self.errors
+            lat = sorted(self.latencies) if self.latencies else []
+            n = len(lat)
+            return {
+                "sent": self.sent,
+                "errors": self.errors,
+                "total": total,
+                "latencies": lat,
+                "count": n,
+                "avg_ms": (sum(lat) / n * 1000) if n else 0,
+                "min_ms": (lat[0] * 1000) if n else 0,
+                "max_ms": (lat[-1] * 1000) if n else 0,
+                "p50_ms": (lat[n // 2] * 1000) if n else 0,
+                "p99_ms": (lat[int(n * 0.99)] * 1000) if n and n >= 100 else (lat[-1] * 1000 if n else 0),
+            }
+
+
+def parse_args():
+    p = argparse.ArgumentParser(
+        description="Generate realistic traffic patterns for AI-Sentinel Isolation Forest.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    p.add_argument(
+        "--mode",
+        choices=["normal", "burst", "attack"],
+        default="normal",
+        help="Traffic pattern: normal (steady), burst (spikes), attack (diverse endpoints/payloads)",
+    )
+    p.add_argument(
+        "--base-url",
+        default="http://localhost:8080",
+        help="Base URL of the target app",
+    )
+    p.add_argument(
+        "--duration",
+        type=float,
+        default=60.0,
+        help="Run duration in seconds (approximate)",
+    )
+    p.add_argument(
+        "--requests-per-second",
+        type=float,
+        default=10.0,
+        dest="rps",
+        help="Target requests per second (normal mode); burst uses multiples",
+    )
+    p.add_argument(
+        "--concurrency",
+        type=int,
+        default=4,
+        help="Number of concurrent workers",
+    )
+    p.add_argument(
+        "--endpoints",
+        default=",".join(DEFAULT_ENDPOINTS),
+        help="Comma-separated paths for diverse/attack mode",
+    )
+    p.add_argument(
+        "--timeout",
+        type=float,
+        default=10.0,
+        help="Request timeout in seconds",
+    )
+    return p.parse_args()
+
+
+def random_headers():
+    h = {
+        "User-Agent": random.choice(USER_AGENTS),
+        "Accept": random.choice(ACCEPT_HEADERS),
+    }
+    if random.random() < 0.3:
+        h["Accept-Language"] = random.choice(["en-US,en;q=0.9", "en-GB,en;q=0.9"])
+    if random.random() < 0.2:
+        h["X-Request-ID"] = f"{random.randint(10000, 99999)}"
+    return h
+
+
+def random_query():
+    if random.random() < 0.5:
+        return ""
+    params = {}
+    if random.random() < 0.4:
+        params["page"] = str(random.randint(1, 20))
+    if random.random() < 0.3:
+        params["limit"] = str(random.choice([10, 20, 50]))
+    if random.random() < 0.2:
+        params["q"] = random.choice(["a", "test", "id"])
+    return urlencode(params) if params else ""
+
+
+def random_payload_size(mode):
+    if mode == "normal":
+        return 0 if random.random() < 0.7 else random.randint(0, 200)
+    if mode == "burst":
+        return random.randint(0, 100)
+    # attack: wider range including large
+    return random.choice([0, 0, 0, random.randint(50, 500), random.randint(500, 2000)])
+
+
+def build_request(url, mode, timeout):
+    query = random_query()
+    if query:
+        full_url = url + ("&" if "?" in url else "?") + query
+    else:
+        full_url = url
+    req = urllib.request.Request(full_url, headers=random_headers(), method="GET")
+    size = random_payload_size(mode)
+    if size > 0:
+        req.add_header("Content-Type", "application/json")
+        req.data = b"x" * size
+        req.method = "POST"
+    return req
+
+
+def send_one(base_url, endpoint, mode, timeout, stats):
+    url = base_url.rstrip("/") + endpoint
+    try:
+        req = build_request(url, mode, timeout)
+        t0 = time.perf_counter()
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            resp.read()
+        elapsed = time.perf_counter() - t0
+        stats.record_success(elapsed)
+    except (urllib.error.URLError, urllib.error.HTTPError, OSError, TimeoutError):
+        stats.record_error()
+
+
+def run_normal(args, stats, stop_at):
+    endpoints = [e.strip() for e in args.endpoints.split(",") if e.strip()] or ["/api/hello"]
+    interval = 1.0 / args.rps if args.rps > 0 else 0
+    delay_per_worker = interval * args.concurrency
+
+    def worker():
+        while time.perf_counter() < stop_at:
+            ep = random.choice(endpoints)
+            send_one(args.base_url, ep, "normal", args.timeout, stats)
+            if delay_per_worker > 0:
+                time.sleep(delay_per_worker)
+
+    with ThreadPoolExecutor(max_workers=args.concurrency) as ex:
+        futs = [ex.submit(worker) for _ in range(args.concurrency)]
+        for f in as_completed(futs):
+            try:
+                f.result()
+            except Exception:
+                pass
+
+
+def run_burst(args, stats, stop_at):
+    endpoints = [e.strip() for e in args.endpoints.split(",") if e.strip()] or ["/api/hello"]
+    burst_rps = max(args.rps * 2, 20)
+    burst_sec = 2.0
+    pause_sec = 1.0
+    interval = 1.0 / burst_rps
+    delay_per_worker = interval * args.concurrency
+
+    def worker():
+        while time.perf_counter() < stop_at:
+            burst_until = time.perf_counter() + burst_sec
+            while time.perf_counter() < burst_until and time.perf_counter() < stop_at:
+                ep = random.choice(endpoints)
+                send_one(args.base_url, ep, "burst", args.timeout, stats)
+                if delay_per_worker > 0:
+                    time.sleep(delay_per_worker)
+            if time.perf_counter() < stop_at:
+                time.sleep(pause_sec)
+
+    with ThreadPoolExecutor(max_workers=args.concurrency) as ex:
+        futs = [ex.submit(worker) for _ in range(args.concurrency)]
+        for f in as_completed(futs):
+            try:
+                f.result()
+            except Exception:
+                pass
+
+
+def run_attack(args, stats, stop_at):
+    endpoints = [e.strip() for e in args.endpoints.split(",") if e.strip()] or ["/api/hello"]
+    interval = 1.0 / args.rps if args.rps > 0 else 0
+    delay_per_worker = interval * args.concurrency
+
+    def worker():
+        while time.perf_counter() < stop_at:
+            ep = random.choice(endpoints)
+            send_one(args.base_url, ep, "attack", args.timeout, stats)
+            if delay_per_worker > 0:
+                time.sleep(delay_per_worker)
+
+    with ThreadPoolExecutor(max_workers=args.concurrency) as ex:
+        futs = [ex.submit(worker) for _ in range(args.concurrency)]
+        for f in as_completed(futs):
+            try:
+                f.result()
+            except Exception:
+                pass
+
+
+def main():
+    args = parse_args()
+    stats = Stats()
+    start = time.perf_counter()
+    stop_at = start + args.duration
+
+    print("AI-Sentinel traffic simulator")
+    print("=" * 50)
+    print(f"Mode:       {args.mode}")
+    print(f"Base URL:   {args.base_url}")
+    print(f"Duration:   ~{args.duration}s")
+    print(f"Target RPS: {args.rps}")
+    print(f"Workers:    {args.concurrency}")
+    print()
+
+    try:
+        if args.mode == "normal":
+            run_normal(args, stats, stop_at)
+        elif args.mode == "burst":
+            run_burst(args, stats, stop_at)
+        else:
+            run_attack(args, stats, stop_at)
+    except KeyboardInterrupt:
+        print("\nInterrupted.", file=sys.stderr)
+
+    elapsed = time.perf_counter() - start
+    elapsed = max(elapsed, 0.001)
+    s = stats.summary()
+    actual_rps = s["total"] / elapsed
+
+    print("Statistics")
+    print("-" * 50)
+    print(f"  Requests sent:   {s['sent']}")
+    print(f"  Errors:          {s['errors']}")
+    print(f"  Total:           {s['total']}")
+    print(f"  Elapsed (s):     {elapsed:.2f}")
+    print(f"  Actual RPS:     {actual_rps:.1f}")
+    if s["count"] > 0:
+        print(f"  Latency (ms):    min={s['min_ms']:.0f}  avg={s['avg_ms']:.0f}  max={s['max_ms']:.0f}  p50={s['p50_ms']:.0f}  p99={s['p99_ms']:.0f}")
+    print()
+    return 0 if s["errors"] == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/train_monitor.py
+++ b/scripts/train_monitor.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+"""
+AI-Sentinel Stage 2: Generate traffic and monitor Isolation Forest training progress.
+
+Polls /actuator/sentinel until isolationForestModelLoaded is true and
+isolationForestModelVersion >= 1. Uses only the Python standard library.
+
+Usage:
+  python scripts/train_monitor.py
+  python scripts/train_monitor.py --base-url http://localhost:8080 --total-requests 200
+"""
+
+import argparse
+import json
+import sys
+import time
+import urllib.error
+import urllib.request
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from threading import Event
+
+
+def parse_args():
+    p = argparse.ArgumentParser(
+        description="Generate traffic and monitor Isolation Forest training until model is loaded.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    p.add_argument(
+        "--base-url",
+        default="http://localhost:8080",
+        help="Base URL of the demo app",
+    )
+    p.add_argument(
+        "--traffic-endpoint",
+        default="/api/hello",
+        help="Path to hit for generating traffic",
+    )
+    p.add_argument(
+        "--total-requests",
+        type=int,
+        default=500,
+        help="Total number of requests to send",
+    )
+    p.add_argument(
+        "--concurrency",
+        type=int,
+        default=4,
+        help="Number of concurrent request workers",
+    )
+    p.add_argument(
+        "--poll-interval",
+        type=float,
+        default=3.0,
+        help="Seconds between actuator polls",
+    )
+    p.add_argument(
+        "--request-delay-ms",
+        type=float,
+        default=10,
+        help="Delay in ms between requests per worker (0 = no delay)",
+    )
+    return p.parse_args()
+
+
+def fetch(url, timeout=10):
+    req = urllib.request.Request(url)
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            return resp.read().decode()
+    except urllib.error.URLError as e:
+        raise ConnectionError(f"{url}: {e.reason}") from e
+
+
+def send_traffic(base_url, path, count, delay_ms, stop_event):
+    url = base_url.rstrip("/") + path
+    sent = 0
+    errors = 0
+    while sent < count and not stop_event.is_set():
+        try:
+            fetch(url, timeout=5)
+            sent += 1
+        except (ConnectionError, OSError):
+            errors += 1
+        if delay_ms > 0:
+            time.sleep(delay_ms / 1000.0)
+    return sent, errors
+
+
+def get_sentinel_info(base_url, timeout=10):
+    url = base_url.rstrip("/") + "/actuator/sentinel"
+    raw = fetch(url, timeout=timeout)
+    return json.loads(raw)
+
+
+def main():
+    args = parse_args()
+    base = args.base_url.rstrip("/")
+    stop_event = Event()
+
+    # Check actuator is reachable before starting
+    try:
+        info = get_sentinel_info(base)
+    except (ConnectionError, OSError, json.JSONDecodeError) as e:
+        print(f"Error: Could not reach {base}/actuator/sentinel — {e}", file=sys.stderr)
+        sys.exit(1)
+
+    print("AI-Sentinel Stage 2 — Isolation Forest training monitor")
+    print("=" * 60)
+    print(f"Base URL:        {base}")
+    print(f"Traffic:        {args.total_requests} requests @ {args.concurrency} workers")
+    print(f"Poll interval:  {args.poll_interval}s")
+    print()
+    if not info.get("isolationForestEnabled"):
+        print("Warning: isolationForestEnabled is false. Enable it in application.yaml and restart.", file=sys.stderr)
+        print("Continuing to send traffic and poll anyway.", file=sys.stderr)
+        print()
+
+    requests_per_worker = (args.total_requests + args.concurrency - 1) // args.concurrency
+    start = time.time()
+
+    def run_worker(_):
+        return send_traffic(
+            base,
+            args.traffic_endpoint,
+            requests_per_worker,
+            args.request_delay_ms,
+            stop_event,
+        )
+
+    info = {}
+    with ThreadPoolExecutor(max_workers=args.concurrency) as executor:
+        futures = [executor.submit(run_worker, i) for i in range(args.concurrency)]
+        last_poll = 0.0
+        done = False
+
+        while not done:
+            now = time.time()
+            if now - last_poll >= args.poll_interval:
+                last_poll = now
+                try:
+                    info = get_sentinel_info(base)
+                except (ConnectionError, OSError, json.JSONDecodeError) as e:
+                    print(f"  [poll error] {e}")
+                    info = {}
+
+                loaded = info.get("isolationForestModelLoaded", False)
+                version = info.get("isolationForestModelVersion", 0) or 0
+                buffered = info.get("isolationForestBufferedSampleCount", 0)
+                last_retrain = info.get("isolationForestLastRetrainTimeMillis") or 0
+                last_retrain_str = time.strftime("%H:%M:%S", time.localtime(last_retrain / 1000)) if last_retrain else "—"
+
+                print(f"  buffered={buffered}  modelLoaded={loaded}  modelVersion={version}  lastRetrain={last_retrain_str}")
+
+                if loaded and version >= 1:
+                    stop_event.set()
+                    done = True
+                    print()
+                    print("Done: Isolation Forest model is trained and loaded.")
+                    break
+
+            time.sleep(0.5)
+            if all(f.done() for f in futures):
+                if not done:
+                    stop_event.set()
+                    total_sent = sum(f.result()[0] for f in futures)
+                    total_errors = sum(f.result()[1] for f in futures)
+                    print()
+                    print(f"All {total_sent} requests sent ({total_errors} errors). Waiting for next poll...")
+                    # One more poll after traffic ends
+                    if now - last_poll >= args.poll_interval - 0.5:
+                        continue
+                done = True
+
+    elapsed = time.time() - start
+    results = [f.result() for f in futures]
+    total_sent = sum(r[0] for r in results)
+    total_errors = sum(r[1] for r in results)
+    print(f"Total requests: {total_sent} (errors: {total_errors}) in {elapsed:.1f}s")
+
+    # Final poll for exit status if we exited on traffic completion
+    if not (info.get("isolationForestModelLoaded") and (info.get("isolationForestModelVersion") or 0) >= 1):
+        try:
+            info = get_sentinel_info(base)
+        except (ConnectionError, OSError, json.JSONDecodeError):
+            pass
+    return 0 if (info.get("isolationForestModelLoaded") and (info.get("isolationForestModelVersion") or 0) >= 1) else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
### Stage 2.2 — Isolation Forest
- **Retrain observability:** Success logs (version, duration, sample count); WARN on failure; `retrainFailureCount` / `lastRetrainFailureTimeMillis` exposed on actuator.
- **Model age:** `getModelAgeMillis()` and actuator fields `isolationForestModelAgeMillis`, `isolationForestRetrainFailureCount`, `isolationForestLastRetrainFailureTimeMillis`.
- **Cold start:** First retrain after `min(retrainInterval, 30s)`; subsequent runs use the configured interval.
- **Config:** `ai.sentinel.isolation-forest.num-trees` (default 100) and `max-depth` (default 10) wired through `SentinelProperties` → `IsolationForestConfig` → `IsolationForestTrainer`.
- **Training quality gate:** When a model exists, samples with IF score > 0.7 are not added to the buffer.

### Actuator fix
- `SentinelEndpointAutoConfiguration` runs **after** `SentinelAutoConfiguration` so the sentinel endpoint bean registers when `CompositeEnforcementHandler` exists (fixes 404 on `/actuator/sentinel`).

### Demo / validation
- `application-stage2.yaml` extended for Stage 2.3 (optional `telemetry` overrides for score logging during validation).
- Reports: `docs/STAGE2_VALIDATION_REPORT.md`, `docs/STAGE2.3_VALIDATION_REPORT.md`.
- `IMPLEMENTATION_STATUS.md` updated with **Stage 2.2 — Operational Hardening**.

### Testing
- `mvn test` on `ai-sentinel-core` and `ai-sentinel-spring-boot-starter`.
- Manual: demo with `stage2` profile; `train_monitor.py` / `traffic_simulator.py` for training and normal vs attack scoring checks.

### Notes
- Composite score in logs is **Statistical + IF** (weighted); IF-only scores are not logged separately unless instrumented later.
- Retrain interval still has a **60s minimum** in the scheduler regardless of `retrain-interval: 15s` in YAML (documented in validation reports).