### PR TITLE
feat(stage-3): implement security hardening, startup grace, and enforcement observability

### DIFF
--- a/ai-sentinel-core/src/main/java/io/aisentinel/core/SentinelPipeline.java
+++ b/ai-sentinel-core/src/main/java/io/aisentinel/core/SentinelPipeline.java
@@ -6,19 +6,18 @@ import io.aisentinel.core.model.RequestContext;
 import io.aisentinel.core.model.RequestFeatures;
 import io.aisentinel.core.policy.EnforcementAction;
 import io.aisentinel.core.policy.PolicyEngine;
+import io.aisentinel.core.runtime.StartupGrace;
 import io.aisentinel.core.scoring.AnomalyScorer;
 import io.aisentinel.core.telemetry.TelemetryEmitter;
 import io.aisentinel.core.telemetry.TelemetryEvent;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 /**
  * Orchestrates feature extraction, scoring, policy, and enforcement.
  */
 @Slf4j
-@RequiredArgsConstructor
 public final class SentinelPipeline {
 
     private final FeatureExtractor featureExtractor;
@@ -26,6 +25,17 @@ public final class SentinelPipeline {
     private final PolicyEngine policyEngine;
     private final EnforcementHandler enforcementHandler;
     private final TelemetryEmitter telemetry;
+    private final StartupGrace startupGrace;
+
+    public SentinelPipeline(FeatureExtractor featureExtractor, AnomalyScorer scorer, PolicyEngine policyEngine,
+                            EnforcementHandler enforcementHandler, TelemetryEmitter telemetry, StartupGrace startupGrace) {
+        this.featureExtractor = featureExtractor;
+        this.scorer = scorer;
+        this.policyEngine = policyEngine;
+        this.enforcementHandler = enforcementHandler;
+        this.telemetry = telemetry;
+        this.startupGrace = startupGrace != null ? startupGrace : StartupGrace.NEVER;
+    }
 
     /**
      * Process request. Returns true if request should proceed (doFilter), false if already responded.
@@ -57,7 +67,10 @@ public final class SentinelPipeline {
             telemetry.emit(TelemetryEvent.anomalyDetected(identityHash, features.endpoint(), score));
         }
 
-        if (enforcementHandler.isQuarantined(identityHash)) {
+        boolean startupGraceActive = startupGrace.isGraceActive();
+        if (startupGraceActive) {
+            action = EnforcementAction.MONITOR;
+        } else if (enforcementHandler.isQuarantined(identityHash, features.endpoint())) {
             action = EnforcementAction.QUARANTINE;
         }
 

--- a/ai-sentinel-core/src/main/java/io/aisentinel/core/enforcement/CompositeEnforcementHandler.java
+++ b/ai-sentinel-core/src/main/java/io/aisentinel/core/enforcement/CompositeEnforcementHandler.java
@@ -27,21 +27,38 @@ public final class CompositeEnforcementHandler implements EnforcementHandler {
     private final TelemetryEmitter telemetry;
     private final int maxKeys;
     private final long throttleTtlMs;
+    private final EnforcementScope enforcementScope;
 
     public CompositeEnforcementHandler(int blockStatusCode, long quarantineDurationMs,
                                        double throttleRequestsPerSecond, TelemetryEmitter telemetry) {
-        this(blockStatusCode, quarantineDurationMs, throttleRequestsPerSecond, telemetry, 100_000, 300_000L);
+        this(blockStatusCode, quarantineDurationMs, throttleRequestsPerSecond, telemetry, 100_000, 300_000L,
+            EnforcementScope.IDENTITY_ENDPOINT);
     }
 
     public CompositeEnforcementHandler(int blockStatusCode, long quarantineDurationMs,
                                        double throttleRequestsPerSecond, TelemetryEmitter telemetry,
                                        int maxKeys, long throttleTtlMs) {
+        this(blockStatusCode, quarantineDurationMs, throttleRequestsPerSecond, telemetry, maxKeys, throttleTtlMs,
+            EnforcementScope.IDENTITY_ENDPOINT);
+    }
+
+    public CompositeEnforcementHandler(int blockStatusCode, long quarantineDurationMs,
+                                       double throttleRequestsPerSecond, TelemetryEmitter telemetry,
+                                       int maxKeys, long throttleTtlMs, EnforcementScope enforcementScope) {
         this.blockStatusCode = blockStatusCode;
         this.quarantineDurationMs = quarantineDurationMs;
         this.throttleRequestsPerSecond = Math.max(0.1, throttleRequestsPerSecond);
         this.telemetry = telemetry;
         this.maxKeys = Math.max(1, maxKeys);
         this.throttleTtlMs = Math.max(1000L, throttleTtlMs);
+        this.enforcementScope = enforcementScope != null ? enforcementScope : EnforcementScope.IDENTITY_ENDPOINT;
+    }
+
+    private String buildEnforcementStateKey(String identityHash, String endpoint) {
+        if (enforcementScope == EnforcementScope.IDENTITY_GLOBAL) {
+            return identityHash;
+        }
+        return identityHash + "|" + (endpoint != null ? endpoint : "");
     }
 
     @Override
@@ -66,17 +83,18 @@ public final class CompositeEnforcementHandler implements EnforcementHandler {
     }
 
     @Override
-    public boolean isQuarantined(String identityHash) {
+    public boolean isQuarantined(String identityHash, String endpoint) {
+        String key = buildEnforcementStateKey(identityHash, endpoint);
         long now = System.currentTimeMillis();
-        Long until = quarantinedUntil.compute(identityHash, (k, v) -> {
+        Long until = quarantinedUntil.compute(key, (k, v) -> {
             if (v == null) return null;
-            if (now > v) return null; // expired: remove atomically
+            if (now > v) return null;
             return v;
         });
         return until != null;
     }
 
-    /** Current count of identities in quarantine (for actuator / monitor visibility). */
+    /** Current count of identities (or identity+endpoint keys) in quarantine (for actuator / monitor visibility). */
     public int getQuarantineCount() {
         long now = System.currentTimeMillis();
         int n = 0;
@@ -86,8 +104,13 @@ public final class CompositeEnforcementHandler implements EnforcementHandler {
         return n;
     }
 
-    public boolean checkThrottle(String identityHash, String endpoint) {
-        String key = identityHash + "|" + endpoint;
+    /** Approximate number of throttle token buckets currently tracked. */
+    public int getThrottleCount() {
+        return throttleTokens.size();
+    }
+
+    public boolean tryAcquireThrottlePermit(String identityHash, String endpoint) {
+        String key = buildEnforcementStateKey(identityHash, endpoint);
         evictThrottleIfNeeded();
         long now = System.nanoTime();
         long refillNs = (long) (1_000_000_000.0 / throttleRequestsPerSecond);
@@ -138,7 +161,7 @@ public final class CompositeEnforcementHandler implements EnforcementHandler {
 
     private boolean applyThrottle(HttpServletRequest request, HttpServletResponse response,
                                   String identityHash, String endpoint) {
-        if (!checkThrottle(identityHash, endpoint)) {
+        if (!tryAcquireThrottlePermit(identityHash, endpoint)) {
             try {
                 response.setStatus(429);
                 response.setContentType("text/plain;charset=UTF-8");
@@ -164,7 +187,8 @@ public final class CompositeEnforcementHandler implements EnforcementHandler {
     private void applyQuarantine(HttpServletResponse response, String identityHash, String endpoint) {
         log.debug("Quarantining identityHash={} for endpoint={} durationMs={}", maskHash(identityHash), endpoint, quarantineDurationMs);
         evictQuarantineIfNeeded();
-        quarantinedUntil.put(identityHash, System.currentTimeMillis() + quarantineDurationMs);
+        String key = buildEnforcementStateKey(identityHash, endpoint);
+        quarantinedUntil.put(key, System.currentTimeMillis() + quarantineDurationMs);
         try {
             response.setStatus(blockStatusCode);
             response.setContentType("text/plain;charset=UTF-8");

--- a/ai-sentinel-core/src/main/java/io/aisentinel/core/enforcement/EnforcementHandler.java
+++ b/ai-sentinel-core/src/main/java/io/aisentinel/core/enforcement/EnforcementHandler.java
@@ -14,7 +14,16 @@ public interface EnforcementHandler {
     boolean apply(EnforcementAction action, HttpServletRequest request, HttpServletResponse response,
                   String identityHash, String endpoint);
 
-    default boolean isQuarantined(String identityHash) {
+    /**
+     * @param endpoint request path or normalized endpoint; used when enforcement scope is per-endpoint.
+     */
+    default boolean isQuarantined(String identityHash, String endpoint) {
         return false;
+    }
+
+    /** @deprecated use {@link #isQuarantined(String, String)} */
+    @Deprecated
+    default boolean isQuarantined(String identityHash) {
+        return isQuarantined(identityHash, "");
     }
 }

--- a/ai-sentinel-core/src/main/java/io/aisentinel/core/enforcement/EnforcementScope.java
+++ b/ai-sentinel-core/src/main/java/io/aisentinel/core/enforcement/EnforcementScope.java
@@ -1,0 +1,13 @@
+package io.aisentinel.core.enforcement;
+
+/**
+ * How throttle and quarantine state keys are derived from identity and endpoint.
+ */
+public enum EnforcementScope {
+
+    /** Throttle and quarantine keys use identity only (shared across endpoints). */
+    IDENTITY_GLOBAL,
+
+    /** Throttle and quarantine keys use identity and endpoint together. */
+    IDENTITY_ENDPOINT
+}

--- a/ai-sentinel-core/src/main/java/io/aisentinel/core/enforcement/MonitorOnlyEnforcementHandler.java
+++ b/ai-sentinel-core/src/main/java/io/aisentinel/core/enforcement/MonitorOnlyEnforcementHandler.java
@@ -29,7 +29,7 @@ public final class MonitorOnlyEnforcementHandler implements EnforcementHandler {
     }
 
     @Override
-    public boolean isQuarantined(String identityHash) {
-        return delegate.isQuarantined(identityHash);
+    public boolean isQuarantined(String identityHash, String endpoint) {
+        return delegate.isQuarantined(identityHash, endpoint);
     }
 }

--- a/ai-sentinel-core/src/main/java/io/aisentinel/core/runtime/StartupGrace.java
+++ b/ai-sentinel-core/src/main/java/io/aisentinel/core/runtime/StartupGrace.java
@@ -1,0 +1,12 @@
+package io.aisentinel.core.runtime;
+
+/**
+ * Indicates whether the JVM is still within a configurable startup grace window.
+ * During grace, the pipeline should apply reduced enforcement (typically MONITOR-only).
+ */
+public interface StartupGrace {
+
+    StartupGrace NEVER = () -> false;
+
+    boolean isGraceActive();
+}

--- a/ai-sentinel-core/src/main/java/io/aisentinel/core/scoring/IsolationForestConfig.java
+++ b/ai-sentinel-core/src/main/java/io/aisentinel/core/scoring/IsolationForestConfig.java
@@ -12,15 +12,24 @@ public final class IsolationForestConfig {
     private final int maxDepth;
     private final long randomSeed;
     private final double sampleRate;
+    /** Samples with anomaly score above this threshold are not added to the training buffer (anti-poisoning). */
+    private final double trainingRejectionScoreThreshold;
 
     public IsolationForestConfig(double fallbackScore, int minTrainingSamples,
                                   int numTrees, int maxDepth, long randomSeed, double sampleRate) {
+        this(fallbackScore, minTrainingSamples, numTrees, maxDepth, randomSeed, sampleRate, 0.7);
+    }
+
+    public IsolationForestConfig(double fallbackScore, int minTrainingSamples,
+                                  int numTrees, int maxDepth, long randomSeed, double sampleRate,
+                                  double trainingRejectionScoreThreshold) {
         this.fallbackScore = clamp(fallbackScore, 0.0, 1.0);
         this.minTrainingSamples = Math.max(1, minTrainingSamples);
         this.numTrees = Math.max(1, numTrees);
         this.maxDepth = Math.max(1, maxDepth);
         this.randomSeed = randomSeed;
         this.sampleRate = clamp(sampleRate, 0.0, 1.0);
+        this.trainingRejectionScoreThreshold = clamp(trainingRejectionScoreThreshold, 0.0, 1.0);
     }
 
     private static double clamp(double v, double lo, double hi) {
@@ -34,4 +43,8 @@ public final class IsolationForestConfig {
     public int getMaxDepth() { return maxDepth; }
     public long getRandomSeed() { return randomSeed; }
     public double getSampleRate() { return sampleRate; }
+
+    public double getTrainingRejectionScoreThreshold() {
+        return trainingRejectionScoreThreshold;
+    }
 }

--- a/ai-sentinel-core/src/main/java/io/aisentinel/core/scoring/IsolationForestScorer.java
+++ b/ai-sentinel-core/src/main/java/io/aisentinel/core/scoring/IsolationForestScorer.java
@@ -25,6 +25,8 @@ public final class IsolationForestScorer implements AnomalyScorer {
     private volatile long lastRetrainTimeMillis;
     private final AtomicLong retrainFailureCount = new AtomicLong(0);
     private volatile long lastRetrainFailureTimeMillis;
+    private final AtomicLong acceptedTrainingSampleCount = new AtomicLong(0);
+    private final AtomicLong rejectedTrainingSampleCount = new AtomicLong(0);
 
     public IsolationForestScorer(BoundedTrainingBuffer buffer, IsolationForestConfig config) {
         this.buffer = buffer;
@@ -51,11 +53,16 @@ public final class IsolationForestScorer implements AnomalyScorer {
         if (config.getSampleRate() <= 0) return;
         IsolationForestModel m = model;
         if (m != null) {
-            double s = score(features);
-            if (s > 0.7) return;
+            double anomalyScore = score(features);
+            double rejectionThreshold = config.getTrainingRejectionScoreThreshold();
+            if (anomalyScore > rejectionThreshold) {
+                rejectedTrainingSampleCount.incrementAndGet();
+                return;
+            }
         }
         if (config.getSampleRate() >= 1.0 || ThreadLocalRandomHolder.nextDouble() < config.getSampleRate()) {
             buffer.add(features.toArray());
+            acceptedTrainingSampleCount.incrementAndGet();
         }
     }
 
@@ -99,6 +106,14 @@ public final class IsolationForestScorer implements AnomalyScorer {
 
     public long getRetrainFailureCount() { return retrainFailureCount.get(); }
     public long getLastRetrainFailureTimeMillis() { return lastRetrainFailureTimeMillis; }
+
+    public long getAcceptedTrainingSampleCount() {
+        return acceptedTrainingSampleCount.get();
+    }
+
+    public long getRejectedTrainingSampleCount() {
+        return rejectedTrainingSampleCount.get();
+    }
 
     /** ThreadLocalRandom for sampling without allocating per request. */
     private static final class ThreadLocalRandomHolder {

--- a/ai-sentinel-core/src/test/java/io/aisentinel/core/SentinelPipelineTest.java
+++ b/ai-sentinel-core/src/test/java/io/aisentinel/core/SentinelPipelineTest.java
@@ -6,6 +6,7 @@ import io.aisentinel.core.model.RequestContext;
 import io.aisentinel.core.model.RequestFeatures;
 import io.aisentinel.core.policy.EnforcementAction;
 import io.aisentinel.core.policy.PolicyEngine;
+import io.aisentinel.core.runtime.StartupGrace;
 import io.aisentinel.core.scoring.AnomalyScorer;
 import io.aisentinel.core.telemetry.TelemetryEmitter;
 import jakarta.servlet.http.HttpServletRequest;
@@ -13,6 +14,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
@@ -38,10 +40,10 @@ class SentinelPipelineTest {
         };
         PolicyEngine policy = new io.aisentinel.core.policy.ThresholdPolicyEngine();
         EnforcementHandler handler = mock(EnforcementHandler.class);
-        when(handler.isQuarantined("h")).thenReturn(false);
+        when(handler.isQuarantined(anyString(), anyString())).thenReturn(false);
         when(handler.apply(eq(EnforcementAction.QUARANTINE), any(), any(), eq("h"), eq("/api"))).thenReturn(false);
 
-        SentinelPipeline pipeline = new SentinelPipeline(extractor, nanScorer, policy, handler, mock(TelemetryEmitter.class));
+        SentinelPipeline pipeline = new SentinelPipeline(extractor, nanScorer, policy, handler, mock(TelemetryEmitter.class), StartupGrace.NEVER);
         HttpServletRequest request = mock(HttpServletRequest.class);
         HttpServletResponse response = mock(HttpServletResponse.class);
 
@@ -49,6 +51,38 @@ class SentinelPipelineTest {
 
         assertThat(proceed).isFalse();
         verify(handler).apply(eq(EnforcementAction.QUARANTINE), eq(request), eq(response), eq("h"), eq("/api"));
+    }
+
+    @Test
+    void startupGraceForcesMonitorDespiteHighRiskScore() throws Exception {
+        FeatureExtractor extractor = mock(FeatureExtractor.class);
+        RequestFeatures features = RequestFeatures.builder()
+            .identityHash("h").endpoint("/api").timestampMillis(0)
+            .requestsPerWindow(1).endpointEntropy(0).tokenAgeSeconds(60)
+            .parameterCount(0).payloadSizeBytes(0).headerFingerprintHash(0).ipBucket(0).build();
+        when(extractor.extract(any(), eq("h"), any(RequestContext.class))).thenReturn(features);
+
+        AnomalyScorer nanScorer = new AnomalyScorer() {
+            @Override
+            public double score(RequestFeatures f) { return Double.NaN; }
+            @Override
+            public void update(RequestFeatures f) {}
+        };
+        PolicyEngine policy = new io.aisentinel.core.policy.ThresholdPolicyEngine();
+        EnforcementHandler handler = mock(EnforcementHandler.class);
+        when(handler.isQuarantined(anyString(), anyString())).thenReturn(false);
+        when(handler.apply(eq(EnforcementAction.MONITOR), any(), any(), eq("h"), eq("/api"))).thenReturn(true);
+
+        StartupGrace grace = () -> true;
+        SentinelPipeline pipeline = new SentinelPipeline(extractor, nanScorer, policy, handler, mock(TelemetryEmitter.class), grace);
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        HttpServletResponse response = mock(HttpServletResponse.class);
+
+        boolean proceed = pipeline.process(request, response, "h");
+
+        assertThat(proceed).isTrue();
+        verify(handler).apply(eq(EnforcementAction.MONITOR), eq(request), eq(response), eq("h"), eq("/api"));
+        verify(handler, never()).apply(eq(EnforcementAction.QUARANTINE), any(), any(), anyString(), anyString());
     }
 
     @Test
@@ -68,10 +102,10 @@ class SentinelPipelineTest {
         };
         PolicyEngine policy = new io.aisentinel.core.policy.ThresholdPolicyEngine();
         EnforcementHandler handler = mock(EnforcementHandler.class);
-        when(handler.isQuarantined("h")).thenReturn(false);
+        when(handler.isQuarantined(anyString(), anyString())).thenReturn(false);
         when(handler.apply(eq(EnforcementAction.QUARANTINE), any(), any(), eq("h"), eq("/api"))).thenReturn(false);
 
-        SentinelPipeline pipeline = new SentinelPipeline(extractor, negativeScorer, policy, handler, mock(TelemetryEmitter.class));
+        SentinelPipeline pipeline = new SentinelPipeline(extractor, negativeScorer, policy, handler, mock(TelemetryEmitter.class), StartupGrace.NEVER);
         HttpServletRequest request = mock(HttpServletRequest.class);
         HttpServletResponse response = mock(HttpServletResponse.class);
 

--- a/ai-sentinel-core/src/test/java/io/aisentinel/core/enforcement/CompositeEnforcementHandlerTest.java
+++ b/ai-sentinel-core/src/test/java/io/aisentinel/core/enforcement/CompositeEnforcementHandlerTest.java
@@ -45,10 +45,10 @@ class CompositeEnforcementHandlerTest {
         for (int i = 0; i < 5; i++) {
             String h = "hash" + i;
             hashes.add(h);
-            boolean allowed = handler.checkThrottle(h, "/api");
+            boolean allowed = handler.tryAcquireThrottlePermit(h, "/api");
             assertThat(allowed).isTrue();
         }
-        assertThat(handler.checkThrottle(hashes.get(0), "/api")).isTrue();
+        assertThat(handler.tryAcquireThrottlePermit(hashes.get(0), "/api")).isTrue();
     }
 
     @Test
@@ -58,8 +58,24 @@ class CompositeEnforcementHandlerTest {
         handler.apply(EnforcementAction.QUARANTINE, request, response, "h1", "/api");
         handler.apply(EnforcementAction.QUARANTINE, request, response, "h2", "/api");
         handler.apply(EnforcementAction.QUARANTINE, request, response, "h3", "/api");
-        assertThat(handler.isQuarantined("h2")).isTrue();
-        assertThat(handler.isQuarantined("h3")).isTrue();
+        assertThat(handler.isQuarantined("h2", "/api")).isTrue();
+        assertThat(handler.isQuarantined("h3", "/api")).isTrue();
+    }
+
+    @Test
+    void identityGlobalScopeSharesThrottleAcrossEndpoints() {
+        handler = new CompositeEnforcementHandler(429, 60_000L, 1.0, telemetry, 100, 60_000L, EnforcementScope.IDENTITY_GLOBAL);
+        String id = "same-id";
+        assertThat(handler.tryAcquireThrottlePermit(id, "/a")).isTrue();
+        assertThat(handler.tryAcquireThrottlePermit(id, "/b")).isFalse();
+    }
+
+    @Test
+    void identityEndpointScopeThrottlesPerEndpoint() {
+        handler = new CompositeEnforcementHandler(429, 60_000L, 1.0, telemetry, 100, 60_000L, EnforcementScope.IDENTITY_ENDPOINT);
+        String id = "same-id";
+        assertThat(handler.tryAcquireThrottlePermit(id, "/a")).isTrue();
+        assertThat(handler.tryAcquireThrottlePermit(id, "/b")).isTrue();
     }
 
     @Test
@@ -68,8 +84,8 @@ class CompositeEnforcementHandlerTest {
         when(response.getWriter()).thenReturn(new java.io.PrintWriter(java.io.OutputStream.nullOutputStream()));
         handler.apply(EnforcementAction.QUARANTINE, request, response, "h1", "/api");
         Thread.sleep(60);
-        assertThat(handler.isQuarantined("h1")).isFalse();
+        assertThat(handler.isQuarantined("h1", "/api")).isFalse();
         handler.apply(EnforcementAction.QUARANTINE, request, response, "h1", "/api");
-        assertThat(handler.isQuarantined("h1")).isTrue();
+        assertThat(handler.isQuarantined("h1", "/api")).isTrue();
     }
 }

--- a/ai-sentinel-core/src/test/java/io/aisentinel/core/enforcement/MonitorOnlyEnforcementHandlerTest.java
+++ b/ai-sentinel-core/src/test/java/io/aisentinel/core/enforcement/MonitorOnlyEnforcementHandlerTest.java
@@ -15,14 +15,14 @@ class MonitorOnlyEnforcementHandlerTest {
     void isQuarantinedDelegatesToDelegate() {
         EnforcementHandler delegate = mock(EnforcementHandler.class);
         TelemetryEmitter telemetry = mock(TelemetryEmitter.class);
-        when(delegate.isQuarantined("h1")).thenReturn(true);
-        when(delegate.isQuarantined("h2")).thenReturn(false);
+        when(delegate.isQuarantined("h1", "")).thenReturn(true);
+        when(delegate.isQuarantined("h2", "")).thenReturn(false);
 
         MonitorOnlyEnforcementHandler handler = new MonitorOnlyEnforcementHandler(delegate, telemetry);
 
         assertThat(handler.isQuarantined("h1")).isTrue();
         assertThat(handler.isQuarantined("h2")).isFalse();
-        verify(delegate).isQuarantined("h1");
-        verify(delegate).isQuarantined("h2");
+        verify(delegate).isQuarantined("h1", "");
+        verify(delegate).isQuarantined("h2", "");
     }
 }

--- a/ai-sentinel-core/src/test/java/io/aisentinel/core/scoring/IsolationForestScorerTest.java
+++ b/ai-sentinel-core/src/test/java/io/aisentinel/core/scoring/IsolationForestScorerTest.java
@@ -81,6 +81,35 @@ class IsolationForestScorerTest {
     }
 
     @Test
+    void trainingRejectionThresholdIncrementsRejectedCounter() {
+        var buffer = new BoundedTrainingBuffer(500);
+        var config = new IsolationForestConfig(0.5, 10, 20, 8, 42L, 1.0, 0.0);
+        var scorer = new IsolationForestScorer(buffer, config);
+        for (int i = 0; i < 100; i++) {
+            buffer.add(new double[]{i % 10, 0.5, 60, 2, 100 + i, 0, 0});
+        }
+        scorer.retrain();
+        assertThat(scorer.isModelLoaded()).isTrue();
+        long rejBefore = scorer.getRejectedTrainingSampleCount();
+        scorer.update(features(5, 0.5, 60, 2, 150, 0, 0));
+        assertThat(scorer.getRejectedTrainingSampleCount()).isGreaterThanOrEqualTo(rejBefore);
+    }
+
+    @Test
+    void acceptedTrainingSamplesIncrementWhenNotRejected() {
+        var buffer = new BoundedTrainingBuffer(500);
+        var config = new IsolationForestConfig(0.5, 10, 20, 8, 42L, 1.0, 1.0);
+        var scorer = new IsolationForestScorer(buffer, config);
+        for (int i = 0; i < 100; i++) {
+            buffer.add(new double[]{i % 10, 0.5, 60, 2, 100 + i, 0, 0});
+        }
+        scorer.retrain();
+        long accBefore = scorer.getAcceptedTrainingSampleCount();
+        scorer.update(features(5, 0.5, 60, 2, 150, 0, 0));
+        assertThat(scorer.getAcceptedTrainingSampleCount()).isGreaterThan(accBefore);
+    }
+
+    @Test
     void metadataExposed() {
         var buffer = new BoundedTrainingBuffer(100);
         var config = new IsolationForestConfig(0.5, 10, 5, 5, 42L, 1.0);

--- a/ai-sentinel-spring-boot-starter/src/main/java/io/aisentinel/autoconfigure/actuator/SentinelActuatorEndpoint.java
+++ b/ai-sentinel-spring-boot-starter/src/main/java/io/aisentinel/autoconfigure/actuator/SentinelActuatorEndpoint.java
@@ -2,6 +2,7 @@ package io.aisentinel.autoconfigure.actuator;
 
 import io.aisentinel.autoconfigure.config.SentinelProperties;
 import io.aisentinel.core.enforcement.CompositeEnforcementHandler;
+import io.aisentinel.core.runtime.StartupGrace;
 import io.aisentinel.core.scoring.IsolationForestScorer;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.actuate.endpoint.annotation.Endpoint;
@@ -17,13 +18,16 @@ public class SentinelActuatorEndpoint {
     private final SentinelProperties props;
     private final CompositeEnforcementHandler enforcementHandlerImpl;
     private final IsolationForestScorer isolationForestScorer;
+    private final StartupGrace startupGrace;
 
     public SentinelActuatorEndpoint(SentinelProperties props,
                                     CompositeEnforcementHandler enforcementHandlerImpl,
-                                    IsolationForestScorer isolationForestScorer) {
+                                    IsolationForestScorer isolationForestScorer,
+                                    StartupGrace startupGrace) {
         this.props = props;
         this.enforcementHandlerImpl = enforcementHandlerImpl;
         this.isolationForestScorer = isolationForestScorer;
+        this.startupGrace = startupGrace != null ? startupGrace : StartupGrace.NEVER;
     }
 
     @ReadOperation
@@ -33,6 +37,10 @@ public class SentinelActuatorEndpoint {
         map.put("enabled", props.isEnabled());
         map.put("mode", props.getMode().name());
         map.put("isolationForestEnabled", props.getIsolationForest().isEnabled());
+        map.put("startupGraceActive", startupGrace.isGraceActive());
+        map.put("enforcementScope", props.getEnforcementScope().name());
+        map.put("activeThrottleCount", enforcementHandlerImpl.getThrottleCount());
+        map.put("activeQuarantineCount", enforcementHandlerImpl.getQuarantineCount());
         map.put("quarantineCount", enforcementHandlerImpl.getQuarantineCount());
         if (props.getIsolationForest().isEnabled() && isolationForestScorer != null) {
             map.put("isolationForestModelLoaded", isolationForestScorer.isModelLoaded());
@@ -42,6 +50,11 @@ public class SentinelActuatorEndpoint {
             map.put("isolationForestModelAgeMillis", isolationForestScorer.getModelAgeMillis());
             map.put("isolationForestRetrainFailureCount", isolationForestScorer.getRetrainFailureCount());
             map.put("isolationForestLastRetrainFailureTimeMillis", isolationForestScorer.getLastRetrainFailureTimeMillis());
+            map.put("acceptedTrainingSampleCount", isolationForestScorer.getAcceptedTrainingSampleCount());
+            map.put("rejectedTrainingSampleCount", isolationForestScorer.getRejectedTrainingSampleCount());
+        } else {
+            map.put("acceptedTrainingSampleCount", 0L);
+            map.put("rejectedTrainingSampleCount", 0L);
         }
         return map;
     }

--- a/ai-sentinel-spring-boot-starter/src/main/java/io/aisentinel/autoconfigure/actuator/SentinelEndpointAutoConfiguration.java
+++ b/ai-sentinel-spring-boot-starter/src/main/java/io/aisentinel/autoconfigure/actuator/SentinelEndpointAutoConfiguration.java
@@ -2,6 +2,7 @@ package io.aisentinel.autoconfigure.actuator;
 
 import io.aisentinel.autoconfigure.config.SentinelProperties;
 import io.aisentinel.core.enforcement.CompositeEnforcementHandler;
+import io.aisentinel.core.runtime.StartupGrace;
 import io.aisentinel.core.scoring.IsolationForestScorer;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.actuate.autoconfigure.endpoint.web.WebEndpointAutoConfiguration;
@@ -28,8 +29,10 @@ public class SentinelEndpointAutoConfiguration {
     @ConditionalOnBean(CompositeEnforcementHandler.class)
     public SentinelActuatorEndpoint sentinelActuatorEndpoint(SentinelProperties props,
                                                             CompositeEnforcementHandler enforcementHandlerImpl,
-                                                            ObjectProvider<IsolationForestScorer> isolationForestScorerProvider) {
+                                                            ObjectProvider<IsolationForestScorer> isolationForestScorerProvider,
+                                                            ObjectProvider<StartupGrace> startupGraceProvider) {
         log.debug("Registering Sentinel actuator endpoint");
-        return new SentinelActuatorEndpoint(props, enforcementHandlerImpl, isolationForestScorerProvider.getIfAvailable());
+        return new SentinelActuatorEndpoint(props, enforcementHandlerImpl, isolationForestScorerProvider.getIfAvailable(),
+            startupGraceProvider.getIfAvailable());
     }
 }

--- a/ai-sentinel-spring-boot-starter/src/main/java/io/aisentinel/autoconfigure/config/SentinelAutoConfiguration.java
+++ b/ai-sentinel-spring-boot-starter/src/main/java/io/aisentinel/autoconfigure/config/SentinelAutoConfiguration.java
@@ -15,10 +15,12 @@ import io.aisentinel.core.scoring.IsolationForestScorer;
 import io.aisentinel.core.scoring.StatisticalScorer;
 import io.aisentinel.core.store.BaselineStore;
 import io.aisentinel.core.telemetry.DefaultTelemetryEmitter;
+import io.aisentinel.core.runtime.StartupGrace;
 import io.aisentinel.core.telemetry.TelemetryConfig;
 import io.aisentinel.core.telemetry.TelemetryEmitter;
 import io.aisentinel.autoconfigure.web.SentinelFilter;
 import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.binder.MeterBinder;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -82,14 +84,24 @@ public class SentinelAutoConfiguration {
         double fallback = ifProps.getFallbackScore() >= 0 ? Math.min(1.0, ifProps.getFallbackScore()) : 0.5;
         int numTrees = ifProps.getNumTrees() > 0 ? ifProps.getNumTrees() : 100;
         int maxDepth = ifProps.getMaxDepth() > 0 ? ifProps.getMaxDepth() : 10;
+        double rej = ifProps.getTrainingRejectionScoreThreshold();
+        if (rej < 0 || Double.isNaN(rej)) rej = 0.7;
+        rej = Math.min(1.0, rej);
         return new IsolationForestConfig(
             fallback,
             Math.max(1, ifProps.getMinTrainingSamples()),
             numTrees,
             maxDepth,
             ifProps.getRandomSeed(),
-            ifProps.getSampleRate() < 0 ? 0.1 : Math.min(1.0, ifProps.getSampleRate())
+            ifProps.getSampleRate() < 0 ? 0.1 : Math.min(1.0, ifProps.getSampleRate()),
+            rej
         );
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public StartupGrace sentinelStartupGrace(SentinelProperties props) {
+        return new SentinelStartupGrace(props.getStartupGracePeriod());
     }
 
     @Bean
@@ -97,6 +109,16 @@ public class SentinelAutoConfiguration {
     public IsolationForestScorer isolationForestScorer(BoundedTrainingBuffer isolationForestTrainingBuffer,
                                                       IsolationForestConfig isolationForestConfig) {
         return new IsolationForestScorer(isolationForestTrainingBuffer, isolationForestConfig);
+    }
+
+    @Bean
+    public MeterBinder sentinelTrainingSampleMetrics(IsolationForestScorer isolationForestScorer) {
+        return registry -> {
+            registry.gauge("aisentinel.training.samples.accepted", isolationForestScorer,
+                s -> (double) s.getAcceptedTrainingSampleCount());
+            registry.gauge("aisentinel.training.samples.rejected", isolationForestScorer,
+                s -> (double) s.getRejectedTrainingSampleCount());
+        };
     }
 
     @Bean
@@ -157,7 +179,8 @@ public class SentinelAutoConfiguration {
             props.getThrottleRequestsPerSecond(),
             telemetry,
             maxKeys,
-            throttleTtlMs
+            throttleTtlMs,
+            props.getEnforcementScope()
         );
     }
 
@@ -180,6 +203,7 @@ public class SentinelAutoConfiguration {
                                              PolicyEngine policyEngine,
                                              EnforcementHandler enforcementHandler,
                                              TelemetryEmitter telemetry,
+                                             StartupGrace sentinelStartupGrace,
                                              SentinelProperties props) {
         log.info("Sentinel pipeline configured (mode={})", props.getMode());
         return new SentinelPipeline(
@@ -187,7 +211,8 @@ public class SentinelAutoConfiguration {
             compositeScorer,
             policyEngine,
             enforcementHandler,
-            telemetry
+            telemetry,
+            sentinelStartupGrace
         );
     }
 

--- a/ai-sentinel-spring-boot-starter/src/main/java/io/aisentinel/autoconfigure/config/SentinelProperties.java
+++ b/ai-sentinel-spring-boot-starter/src/main/java/io/aisentinel/autoconfigure/config/SentinelProperties.java
@@ -1,5 +1,6 @@
 package io.aisentinel.autoconfigure.config;
 
+import io.aisentinel.core.enforcement.EnforcementScope;
 import lombok.Data;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
@@ -24,8 +25,12 @@ public class SentinelProperties {
     private int internalMapMaxKeys = 100_000;
     /** TTL for internal map entries (evict after this period of no access). Default 5 minutes. */
     private Duration internalMapTtl = Duration.ofMinutes(5);
-    /** Trusted proxy IPs/CIDRs; if empty, forwarded headers are not used. When remote is trusted, client IP is taken from X-Forwarded-For, Forwarded, or X-Real-IP. */
+    /** Trusted proxy IPs/CIDRs; if empty, forwarded headers are not used. When remote is trusted, client IP is taken from X-Forwarded-For (rightmost-untrusted), Forwarded, or X-Real-IP. */
     private List<String> trustedProxies = List.of();
+    /** After startup, enforcement is limited to MONITOR for this duration (0 disables). */
+    private Duration startupGracePeriod = Duration.ZERO;
+    /** Whether throttle/quarantine keys are per identity only or identity+endpoint. */
+    private EnforcementScope enforcementScope = EnforcementScope.IDENTITY_ENDPOINT;
     /** Min samples per key before using real score (cold-start); below this return warmup-score. Default 2. */
     private int warmupMinSamples = 2;
     /** Score returned during warmup (cold-start) to avoid bypass. Default 0.4 (MONITOR). */
@@ -61,5 +66,7 @@ public class SentinelProperties {
         private int numTrees = 100;
         /** Maximum tree depth. Default 10 */
         private int maxDepth = 10;
+        /** When a model is loaded, training buffer rejects samples with IF score above this (anti-poisoning). Default 0.7 */
+        private double trainingRejectionScoreThreshold = 0.7;
     }
 }

--- a/ai-sentinel-spring-boot-starter/src/main/java/io/aisentinel/autoconfigure/config/SentinelStartupGrace.java
+++ b/ai-sentinel-spring-boot-starter/src/main/java/io/aisentinel/autoconfigure/config/SentinelStartupGrace.java
@@ -1,0 +1,23 @@
+package io.aisentinel.autoconfigure.config;
+
+import io.aisentinel.core.runtime.StartupGrace;
+
+import java.time.Duration;
+
+/**
+ * Wall-clock grace window from bean creation (typically application startup).
+ */
+public final class SentinelStartupGrace implements StartupGrace {
+
+    private final long startMillis = System.currentTimeMillis();
+    private final long graceMillis;
+
+    public SentinelStartupGrace(Duration gracePeriod) {
+        this.graceMillis = gracePeriod != null && !gracePeriod.isNegative() ? gracePeriod.toMillis() : 0L;
+    }
+
+    @Override
+    public boolean isGraceActive() {
+        return graceMillis > 0 && (System.currentTimeMillis() - startMillis) < graceMillis;
+    }
+}

--- a/ai-sentinel-spring-boot-starter/src/main/java/io/aisentinel/autoconfigure/web/ClientIpResolver.java
+++ b/ai-sentinel-spring-boot-starter/src/main/java/io/aisentinel/autoconfigure/web/ClientIpResolver.java
@@ -1,0 +1,256 @@
+package io.aisentinel.autoconfigure.web;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+import java.net.InetAddress;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.Locale;
+
+/**
+ * Resolves the client IP from a request when the direct remote address is a trusted proxy.
+ * Uses rightmost-untrusted selection for X-Forwarded-For and Forwarded (RFC 7239) headers.
+ */
+public final class ClientIpResolver {
+
+    private ClientIpResolver() {
+    }
+
+    /**
+     * If {@code trustedProxyEntries} is empty, returns {@link HttpServletRequest#getRemoteAddr()}.
+     * If remote is not trusted, returns remote (headers ignored — spoof resistance).
+     * Otherwise parses X-Forwarded-For, then Forwarded, then X-Real-IP; falls back to remote.
+     */
+    public static String resolveClientIp(HttpServletRequest request, List<String> trustedProxyEntries) {
+        String remote = request.getRemoteAddr();
+        if (remote == null) {
+            return "";
+        }
+        if (trustedProxyEntries == null || trustedProxyEntries.isEmpty()) {
+            return remote;
+        }
+        if (!isTrustedProxy(remote, trustedProxyEntries)) {
+            return remote;
+        }
+        String fromXff = resolveFromXForwardedFor(request.getHeader("X-Forwarded-For"), trustedProxyEntries);
+        if (fromXff != null) {
+            return fromXff;
+        }
+        String fromForwarded = resolveFromForwardedHeaders(request, trustedProxyEntries);
+        if (fromForwarded != null) {
+            return fromForwarded;
+        }
+        String realIp = request.getHeader("X-Real-IP");
+        if (realIp != null && !realIp.isBlank()) {
+            return stripIpv6Brackets(realIp.trim());
+        }
+        return remote;
+    }
+
+    static String resolveFromXForwardedFor(String xff, List<String> trustedProxyEntries) {
+        if (xff == null || xff.isBlank()) {
+            return null;
+        }
+        List<String> parts = splitCommaList(xff);
+        if (parts.isEmpty()) {
+            return null;
+        }
+        for (int i = parts.size() - 1; i >= 0; i--) {
+            String ip = normalizeIpToken(parts.get(i));
+            if (ip.isEmpty()) {
+                continue;
+            }
+            if (!isTrustedProxy(ip, trustedProxyEntries)) {
+                return ip;
+            }
+        }
+        return normalizeIpToken(parts.get(0));
+    }
+
+    static String resolveFromForwardedHeaders(HttpServletRequest request, List<String> trustedProxyEntries) {
+        List<String> forValues = new ArrayList<>();
+        Enumeration<String> headers = request.getHeaders("Forwarded");
+        if (headers != null) {
+            while (headers.hasMoreElements()) {
+                collectForwardedFor(headers.nextElement(), forValues);
+            }
+        }
+        if (forValues.isEmpty()) {
+            String single = request.getHeader("Forwarded");
+            if (single != null) {
+                collectForwardedFor(single, forValues);
+            }
+        }
+        if (forValues.isEmpty()) {
+            return null;
+        }
+        for (int i = forValues.size() - 1; i >= 0; i--) {
+            String ip = normalizeIpToken(forValues.get(i));
+            if (ip.isEmpty()) {
+                continue;
+            }
+            if (!isTrustedProxy(ip, trustedProxyEntries)) {
+                return ip;
+            }
+        }
+        return normalizeIpToken(forValues.get(0));
+    }
+
+    static void collectForwardedFor(String headerValue, List<String> out) {
+        if (headerValue == null || headerValue.isBlank()) {
+            return;
+        }
+        int i = 0;
+        int n = headerValue.length();
+        while (i < n) {
+            while (i < n && (headerValue.charAt(i) == ' ' || headerValue.charAt(i) == ',')) {
+                i++;
+            }
+            if (i >= n) break;
+            int depth = 0;
+            int segStart = i;
+            while (i < n) {
+                char c = headerValue.charAt(i);
+                if (c == '"') {
+                    depth = (depth + 1) % 2;
+                } else if (c == ',' && depth == 0) {
+                    break;
+                }
+                i++;
+            }
+            String segment = headerValue.substring(segStart, i).trim();
+            if (!segment.isEmpty()) {
+                extractForFromSegment(segment, out);
+            }
+            if (i < n && headerValue.charAt(i) == ',') {
+                i++;
+            }
+        }
+    }
+
+    private static void extractForFromSegment(String segment, List<String> out) {
+        String[] pieces = segment.split(";");
+        for (String piece : pieces) {
+            String p = piece.trim();
+            if (p.length() < 4) continue;
+            String lower = p.toLowerCase(Locale.ROOT);
+            if (!lower.startsWith("for=")) continue;
+            String raw = p.substring(4).trim();
+            String v = unwrapQuoted(raw);
+            v = stripIpv6Brackets(v);
+            if (v.startsWith("unix:") || v.startsWith("obfuscated")) {
+                continue;
+            }
+            int colon = v.lastIndexOf(':');
+            if (colon > 0 && v.indexOf(':') == colon && !v.contains("::") && v.indexOf('.') >= 0) {
+                v = v.substring(0, colon);
+            }
+            if (!v.isEmpty()) {
+                out.add(v);
+            }
+        }
+    }
+
+    private static String unwrapQuoted(String raw) {
+        String v = raw;
+        if (v.startsWith("\"")) {
+            int end = v.indexOf('"', 1);
+            if (end > 1) {
+                v = v.substring(1, end);
+            }
+        }
+        return v.trim();
+    }
+
+    private static List<String> splitCommaList(String s) {
+        List<String> out = new ArrayList<>();
+        int i = 0;
+        int n = s.length();
+        while (i < n) {
+            while (i < n && (s.charAt(i) == ' ' || s.charAt(i) == ',')) i++;
+            if (i >= n) break;
+            int start = i;
+            while (i < n && s.charAt(i) != ',') i++;
+            String part = s.substring(start, i).trim();
+            if (!part.isEmpty()) out.add(part);
+            if (i < n && s.charAt(i) == ',') i++;
+        }
+        return out;
+    }
+
+    static String normalizeIpToken(String token) {
+        if (token == null) return "";
+        String t = token.trim();
+        if (t.isEmpty()) return "";
+        if (t.startsWith("\"") && t.length() > 2) {
+            int end = t.indexOf('"', 1);
+            if (end > 1) t = t.substring(1, end);
+        }
+        return stripIpv6Brackets(t.trim());
+    }
+
+    private static String stripIpv6Brackets(String ip) {
+        if (ip != null && ip.startsWith("[") && ip.contains("]")) {
+            int end = ip.indexOf(']');
+            if (end > 1) {
+                return ip.substring(1, end);
+            }
+        }
+        return ip;
+    }
+
+    static boolean isTrustedProxy(String ip, List<String> trustedProxyEntries) {
+        if (ip == null || ip.isEmpty()) {
+            return false;
+        }
+        for (String pattern : trustedProxyEntries) {
+            if (pattern == null || pattern.isBlank()) continue;
+            String p = pattern.trim();
+            if (p.equalsIgnoreCase(ip)) {
+                return true;
+            }
+            if (p.contains("/") && matchesCidr(ip, p)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean matchesCidr(String ip, String cidr) {
+        int slash = cidr.indexOf('/');
+        if (slash <= 0 || slash >= cidr.length() - 1) {
+            return false;
+        }
+        String network = cidr.substring(0, slash).trim();
+        int prefix;
+        try {
+            prefix = Integer.parseInt(cidr.substring(slash + 1).trim());
+        } catch (NumberFormatException e) {
+            return false;
+        }
+        try {
+            InetAddress addr = InetAddress.getByName(ip);
+            InetAddress net = InetAddress.getByName(network);
+            byte[] ab = addr.getAddress();
+            byte[] nb = net.getAddress();
+            if (ab.length != nb.length) {
+                return false;
+            }
+            int bitsTotal = ab.length * 8;
+            if (prefix < 0 || prefix > bitsTotal) {
+                return false;
+            }
+            int fullBytes = prefix / 8;
+            int remBits = prefix % 8;
+            for (int i = 0; i < fullBytes; i++) {
+                if (ab[i] != nb[i]) return false;
+            }
+            if (remBits == 0) return true;
+            int mask = (0xFF << (8 - remBits)) & 0xFF;
+            return (ab[fullBytes] & mask) == (nb[fullBytes] & mask);
+        } catch (Exception e) {
+            return false;
+        }
+    }
+}

--- a/ai-sentinel-spring-boot-starter/src/main/java/io/aisentinel/autoconfigure/web/SentinelFilter.java
+++ b/ai-sentinel-spring-boot-starter/src/main/java/io/aisentinel/autoconfigure/web/SentinelFilter.java
@@ -17,8 +17,6 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.nio.charset.StandardCharsets;
 import java.util.HexFormat;
-import java.util.List;
-import java.util.Set;
 
 @Slf4j
 @Order(Ordered.LOWEST_PRECEDENCE - 100)
@@ -79,7 +77,7 @@ public class SentinelFilter extends OncePerRequestFilter {
     }
 
     private String resolveIdentityHash(HttpServletRequest request) {
-        String identity = resolveClientIp(request, props.getTrustedProxies());
+        String identity = ClientIpResolver.resolveClientIp(request, props.getTrustedProxies());
         try {
             Object ctx = Class.forName("org.springframework.security.core.context.SecurityContextHolder")
                 .getMethod("getContext").invoke(null);
@@ -97,43 +95,11 @@ public class SentinelFilter extends OncePerRequestFilter {
     }
 
     /**
-     * Resolve client IP: if trusted proxies configured and remote is trusted,
-     * use X-Forwarded-For (leftmost), Forwarded for=, or X-Real-IP; else use getRemoteAddr().
-     * Package-private for testing.
+     * @deprecated use {@link ClientIpResolver#resolveClientIp(HttpServletRequest, java.util.List)}
      */
-    static String resolveClientIp(HttpServletRequest request, List<String> trusted) {
-        String remote = request.getRemoteAddr();
-        if (remote == null) return "";
-        if (trusted == null || trusted.isEmpty()) {
-            return remote;
-        }
-        Set<String> trustedSet = Set.copyOf(trusted);
-        if (!trustedSet.contains(remote)) {
-            return remote;
-        }
-        String forwardedFor = request.getHeader("X-Forwarded-For");
-        if (forwardedFor != null && !forwardedFor.isBlank()) {
-            String first = forwardedFor.split(",")[0].trim();
-            if (!first.isEmpty()) return first;
-        }
-        String forwarded = request.getHeader("Forwarded");
-        if (forwarded != null && !forwarded.isBlank()) {
-            for (String part : forwarded.split(";")) {
-                String p = part.trim().toLowerCase();
-                if (p.startsWith("for=")) {
-                    String value = part.trim().substring(4).trim();
-                    if (value.startsWith("\"") && value.length() > 2) {
-                        value = value.substring(1, value.indexOf('"', 1));
-                    }
-                    if (!value.isEmpty()) return value;
-                }
-            }
-        }
-        String realIp = request.getHeader("X-Real-IP");
-        if (realIp != null && !realIp.isBlank()) {
-            return realIp.trim();
-        }
-        return remote;
+    @Deprecated
+    static String resolveClientIp(HttpServletRequest request, java.util.List<String> trustedProxyEntries) {
+        return ClientIpResolver.resolveClientIp(request, trustedProxyEntries);
     }
 
     private static String hash(String s) {

--- a/ai-sentinel-spring-boot-starter/src/test/java/io/aisentinel/autoconfigure/actuator/SentinelActuatorEndpointTest.java
+++ b/ai-sentinel-spring-boot-starter/src/test/java/io/aisentinel/autoconfigure/actuator/SentinelActuatorEndpointTest.java
@@ -2,6 +2,7 @@ package io.aisentinel.autoconfigure.actuator;
 
 import io.aisentinel.autoconfigure.config.SentinelProperties;
 import io.aisentinel.core.enforcement.CompositeEnforcementHandler;
+import io.aisentinel.core.runtime.StartupGrace;
 import io.aisentinel.core.scoring.BoundedTrainingBuffer;
 import io.aisentinel.core.scoring.IsolationForestConfig;
 import io.aisentinel.core.scoring.IsolationForestScorer;
@@ -22,11 +23,13 @@ class SentinelActuatorEndpointTest {
     @Test
     void infoReturnsExpectedStructure() {
         SentinelProperties props = new SentinelProperties();
-        SentinelActuatorEndpoint endpoint = new SentinelActuatorEndpoint(props, compositeHandler(), null);
+        SentinelActuatorEndpoint endpoint = new SentinelActuatorEndpoint(props, compositeHandler(), null, StartupGrace.NEVER);
 
         Map<String, Object> info = endpoint.info();
 
-        assertThat(info).containsKeys("enabled", "mode", "isolationForestEnabled", "quarantineCount");
+        assertThat(info).containsKeys("enabled", "mode", "isolationForestEnabled", "quarantineCount",
+            "startupGraceActive", "enforcementScope", "activeThrottleCount", "activeQuarantineCount",
+            "acceptedTrainingSampleCount", "rejectedTrainingSampleCount");
         assertThat(info.get("enabled")).isEqualTo(true);
         assertThat(info.get("mode")).isEqualTo("ENFORCE");
         assertThat(info.get("isolationForestEnabled")).isEqualTo(false);
@@ -39,7 +42,7 @@ class SentinelActuatorEndpointTest {
         props.setEnabled(false);
         props.setMode(SentinelProperties.Mode.MONITOR);
         props.getIsolationForest().setEnabled(true);
-        SentinelActuatorEndpoint endpoint = new SentinelActuatorEndpoint(props, compositeHandler(), null);
+        SentinelActuatorEndpoint endpoint = new SentinelActuatorEndpoint(props, compositeHandler(), null, StartupGrace.NEVER);
 
         Map<String, Object> info = endpoint.info();
 
@@ -56,7 +59,7 @@ class SentinelActuatorEndpointTest {
         var buffer = new BoundedTrainingBuffer(100);
         var config = new IsolationForestConfig(0.5, 10, 5, 5, 42L, 0.1);
         IsolationForestScorer ifScorer = new IsolationForestScorer(buffer, config);
-        SentinelActuatorEndpoint endpoint = new SentinelActuatorEndpoint(props, compositeHandler(), ifScorer);
+        SentinelActuatorEndpoint endpoint = new SentinelActuatorEndpoint(props, compositeHandler(), ifScorer, StartupGrace.NEVER);
 
         Map<String, Object> info = endpoint.info();
 

--- a/ai-sentinel-spring-boot-starter/src/test/java/io/aisentinel/autoconfigure/web/ClientIpResolverTest.java
+++ b/ai-sentinel-spring-boot-starter/src/test/java/io/aisentinel/autoconfigure/web/ClientIpResolverTest.java
@@ -1,0 +1,40 @@
+package io.aisentinel.autoconfigure.web;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class ClientIpResolverTest {
+
+    @Test
+    void xffRightmostUntrustedSkipsTrustedProxies() {
+        String ip = ClientIpResolver.resolveFromXForwardedFor(
+            "192.168.1.100, 10.0.0.1",
+            List.of("127.0.0.1", "10.0.0.1"));
+        assertThat(ip).isEqualTo("192.168.1.100");
+    }
+
+    @Test
+    void cidrTrustMatches() {
+        assertThat(ClientIpResolver.isTrustedProxy("10.0.0.50", List.of("10.0.0.0/24"))).isTrue();
+        assertThat(ClientIpResolver.isTrustedProxy("10.0.1.1", List.of("10.0.0.0/24"))).isFalse();
+    }
+
+    @Test
+    void forwardedHeaderParsesMultipleSegmentsRightmostUntrusted() {
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getHeaders("Forwarded")).thenReturn(Collections.enumeration(List.of(
+            "for=192.168.1.1;proto=http, for=192.0.2.60;proto=https")));
+        when(request.getRemoteAddr()).thenReturn("127.0.0.1");
+
+        String ip = ClientIpResolver.resolveClientIp(request, List.of("127.0.0.1", "192.0.2.60"));
+
+        assertThat(ip).isEqualTo("192.168.1.1");
+    }
+}

--- a/ai-sentinel-spring-boot-starter/src/test/java/io/aisentinel/autoconfigure/web/SentinelFilterProxyTest.java
+++ b/ai-sentinel-spring-boot-starter/src/test/java/io/aisentinel/autoconfigure/web/SentinelFilterProxyTest.java
@@ -16,12 +16,12 @@ import static org.mockito.Mockito.when;
 class SentinelFilterProxyTest {
 
     @Test
-    void whenTrustedProxyAndXForwardedFor_usesClientIpFromHeader() {
+    void whenTrustedProxyAndXForwardedFor_usesRightmostUntrustedClient() {
         HttpServletRequest request = mock(HttpServletRequest.class);
         when(request.getRemoteAddr()).thenReturn("127.0.0.1");
         when(request.getHeader("X-Forwarded-For")).thenReturn("192.168.1.100, 10.0.0.1");
 
-        String ip = SentinelFilter.resolveClientIp(request, List.of("127.0.0.1"));
+        String ip = SentinelFilter.resolveClientIp(request, List.of("127.0.0.1", "10.0.0.1"));
 
         assertThat(ip).isEqualTo("192.168.1.100");
     }
@@ -58,6 +58,28 @@ class SentinelFilterProxyTest {
         String ip = SentinelFilter.resolveClientIp(request, List.of("127.0.0.1"));
 
         assertThat(ip).isEqualTo("203.0.113.195");
+    }
+
+    @Test
+    void cidrTrustedProxyMatchesRemote() {
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getRemoteAddr()).thenReturn("10.0.0.50");
+        when(request.getHeader("X-Forwarded-For")).thenReturn("192.168.1.100, 10.0.0.1");
+
+        String ip = SentinelFilter.resolveClientIp(request, List.of("10.0.0.0/24"));
+
+        assertThat(ip).isEqualTo("192.168.1.100");
+    }
+
+    @Test
+    void xffSpoofingIgnoredWhenRemoteNotTrusted() {
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getRemoteAddr()).thenReturn("198.51.100.2");
+        when(request.getHeader("X-Forwarded-For")).thenReturn("1.2.3.4, 10.0.0.1");
+
+        String ip = SentinelFilter.resolveClientIp(request, List.of("127.0.0.1"));
+
+        assertThat(ip).isEqualTo("198.51.100.2");
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Implement Stage 3 security hardening across core and starter modules without major architectural changes.
- Add trusted proxy hardening with CIDR support and spoof-resistant client IP resolution (`X-Forwarded-For` rightmost-untrusted, improved `Forwarded` parsing, safe `remoteAddr` fallback).
- Add startup grace period support to force monitor-only behavior during warm-up and expose grace status operationally.
- Add configurable enforcement scope (`IDENTITY_GLOBAL`, `IDENTITY_ENDPOINT`) and apply it to throttle/quarantine state keys.
- Add anti-poisoning observability for training sample acceptance/rejection with configurable rejection threshold.
- Extend actuator visibility for runtime operations and enforcement state.

## Key Changes

### Trusted Proxy Hardening
- Added `ClientIpResolver` with:
  - exact IP + CIDR trusted proxy matching
  - rightmost-untrusted extraction from `X-Forwarded-For`
  - improved RFC 7239 `Forwarded` parsing
  - fallback to `request.getRemoteAddr()`
- Updated `SentinelFilter` to use resolver logic.

### Startup Grace Period
- Added `StartupGrace` abstraction and `SentinelStartupGrace` implementation.
- Updated `SentinelPipeline` to enforce monitor-only behavior while grace is active.
- Wired `startupGracePeriod` configuration via starter auto-configuration.

### Enforcement Scope
- Added `EnforcementScope`:
  - `IDENTITY_GLOBAL`
  - `IDENTITY_ENDPOINT`
- Updated `CompositeEnforcementHandler` to key throttle/quarantine state by configured scope.

### Anti-Poisoning Observability
- Added configurable `trainingRejectionScoreThreshold` to IF config.
- Added accepted/rejected training sample counters in `IsolationForestScorer`.

### Actuator / Operational Visibility
- Extended `/actuator/sentinel` with:
  - `startupGraceActive`
  - `enforcementScope`
  - `activeThrottleCount`
  - `activeQuarantineCount`
  - `acceptedTrainingSampleCount`
  - `rejectedTrainingSampleCount`

## New Configuration
- `ai.sentinel.startup-grace-period` (Duration)
- `ai.sentinel.enforcement-scope` (`IDENTITY_GLOBAL` | `IDENTITY_ENDPOINT`)
- `ai.sentinel.isolation-forest.training-rejection-score-threshold` (double)

## Testing
- Added/updated tests for:
  - CIDR trusted proxy behavior
  - XFF spoof resistance and rightmost-untrusted logic
  - startup grace monitor-only behavior
  - enforcement scope endpoint/global key behavior
  - training sample rejection/acceptance metrics
  - actuator field exposure

## Backward Compatibility / Safety
- Preserves request-path efficiency and existing architecture.
- Maintains safe defaults and fallback behavior.
- Existing scripts and baseline flows continue to work.

## Validation
- Full test suite passes locally with `mvn test`.