### PR TITLE
feat(stage-4): add Micrometer observability, pipeline metrics, and actuator summaries

### DIFF
--- a/ai-sentinel-core/src/main/java/io/aisentinel/core/SentinelPipeline.java
+++ b/ai-sentinel-core/src/main/java/io/aisentinel/core/SentinelPipeline.java
@@ -6,6 +6,7 @@ import io.aisentinel.core.model.RequestContext;
 import io.aisentinel.core.model.RequestFeatures;
 import io.aisentinel.core.policy.EnforcementAction;
 import io.aisentinel.core.policy.PolicyEngine;
+import io.aisentinel.core.metrics.SentinelMetrics;
 import io.aisentinel.core.runtime.StartupGrace;
 import io.aisentinel.core.scoring.AnomalyScorer;
 import io.aisentinel.core.telemetry.TelemetryEmitter;
@@ -26,55 +27,74 @@ public final class SentinelPipeline {
     private final EnforcementHandler enforcementHandler;
     private final TelemetryEmitter telemetry;
     private final StartupGrace startupGrace;
+    private final SentinelMetrics metrics;
 
     public SentinelPipeline(FeatureExtractor featureExtractor, AnomalyScorer scorer, PolicyEngine policyEngine,
-                            EnforcementHandler enforcementHandler, TelemetryEmitter telemetry, StartupGrace startupGrace) {
+                            EnforcementHandler enforcementHandler, TelemetryEmitter telemetry, StartupGrace startupGrace,
+                            SentinelMetrics metrics) {
         this.featureExtractor = featureExtractor;
         this.scorer = scorer;
         this.policyEngine = policyEngine;
         this.enforcementHandler = enforcementHandler;
         this.telemetry = telemetry;
         this.startupGrace = startupGrace != null ? startupGrace : StartupGrace.NEVER;
+        this.metrics = metrics != null ? metrics : SentinelMetrics.NOOP;
     }
 
     /**
      * Process request. Returns true if request should proceed (doFilter), false if already responded.
      */
     public boolean process(HttpServletRequest request, HttpServletResponse response, String identityHash) {
-        RequestContext ctx = new RequestContext();
-        RequestFeatures features;
+        long pipelineStart = System.nanoTime();
         try {
-            features = featureExtractor.extract(request, identityHash, ctx);
-        } catch (Exception e) {
-            log.debug("Feature extraction failed for {}: {}", request.getRequestURI(), e.getMessage());
-            return true;
+            RequestContext ctx = new RequestContext();
+            RequestFeatures features;
+            try {
+                features = featureExtractor.extract(request, identityHash, ctx);
+            } catch (Exception e) {
+                log.debug("Feature extraction failed for {}: {}", request.getRequestURI(), e.getMessage());
+                metrics.recordFailOpen();
+                return true;
+            }
+
+            double rawScore;
+            long scoreStart = System.nanoTime();
+            try {
+                rawScore = scorer.score(features);
+                scorer.update(features);
+            } catch (Exception e) {
+                log.debug("Scoring failed for {}: {}", features.endpoint(), e.getMessage());
+                metrics.recordScoringError();
+                metrics.recordFailOpen();
+                return true;
+            } finally {
+                metrics.recordScoringLatencyNanos(System.nanoTime() - scoreStart);
+            }
+
+            if (Double.isNaN(rawScore) || rawScore < 0) {
+                metrics.recordNanOrNegativeScoreClamped();
+            }
+            double score = clampScore(rawScore);
+
+            EnforcementAction action = policyEngine.evaluate(score, features, features.endpoint());
+
+            telemetry.emit(TelemetryEvent.threatScored(identityHash, features.endpoint(), score));
+            if (score > 0.5) {
+                telemetry.emit(TelemetryEvent.anomalyDetected(identityHash, features.endpoint(), score));
+            }
+
+            boolean startupGraceActive = startupGrace.isGraceActive();
+            if (startupGraceActive) {
+                action = EnforcementAction.MONITOR;
+            } else if (enforcementHandler.isQuarantined(identityHash, features.endpoint())) {
+                action = EnforcementAction.QUARANTINE;
+            }
+
+            metrics.recordPolicyAction(action);
+            return enforcementHandler.apply(action, request, response, identityHash, features.endpoint());
+        } finally {
+            metrics.recordPipelineLatencyNanos(System.nanoTime() - pipelineStart);
         }
-
-        double score;
-        try {
-            score = scorer.score(features);
-            scorer.update(features);
-        } catch (Exception e) {
-            log.debug("Scoring failed for {}: {}", features.endpoint(), e.getMessage());
-            return true;
-        }
-        score = clampScore(score);
-
-        EnforcementAction action = policyEngine.evaluate(score, features, features.endpoint());
-
-        telemetry.emit(TelemetryEvent.threatScored(identityHash, features.endpoint(), score));
-        if (score > 0.5) {
-            telemetry.emit(TelemetryEvent.anomalyDetected(identityHash, features.endpoint(), score));
-        }
-
-        boolean startupGraceActive = startupGrace.isGraceActive();
-        if (startupGraceActive) {
-            action = EnforcementAction.MONITOR;
-        } else if (enforcementHandler.isQuarantined(identityHash, features.endpoint())) {
-            action = EnforcementAction.QUARANTINE;
-        }
-
-        return enforcementHandler.apply(action, request, response, identityHash, features.endpoint());
     }
 
     /** Prevents NaN or out-of-range scores from causing policy bypass; treat NaN as high risk. */

--- a/ai-sentinel-core/src/main/java/io/aisentinel/core/feature/DefaultFeatureExtractor.java
+++ b/ai-sentinel-core/src/main/java/io/aisentinel/core/feature/DefaultFeatureExtractor.java
@@ -187,6 +187,11 @@ public final class DefaultFeatureExtractor implements FeatureExtractor {
         return h.hashCode();
     }
 
+    @Override
+    public int metricsEndpointHistoryEntryCount() {
+        return endpointHistory.size();
+    }
+
     private int extractIpBucket(HttpServletRequest request) {
         String ip = request.getRemoteAddr();
         if (ip == null) return 0;

--- a/ai-sentinel-core/src/main/java/io/aisentinel/core/feature/FeatureExtractor.java
+++ b/ai-sentinel-core/src/main/java/io/aisentinel/core/feature/FeatureExtractor.java
@@ -10,4 +10,11 @@ import jakarta.servlet.http.HttpServletRequest;
 public interface FeatureExtractor {
 
     RequestFeatures extract(HttpServletRequest request, String identityHash, RequestContext ctx);
+
+    /**
+     * Size of extractor-internal caches for metrics (e.g. endpoint history). Default none.
+     */
+    default int metricsEndpointHistoryEntryCount() {
+        return 0;
+    }
 }

--- a/ai-sentinel-core/src/main/java/io/aisentinel/core/metrics/SentinelMetrics.java
+++ b/ai-sentinel-core/src/main/java/io/aisentinel/core/metrics/SentinelMetrics.java
@@ -1,0 +1,45 @@
+package io.aisentinel.core.metrics;
+
+import io.aisentinel.core.policy.EnforcementAction;
+
+/**
+ * Optional observability hooks for Sentinel (no Micrometer/Spring dependency in core).
+ * Default methods are no-ops; production wiring is provided by the Spring Boot starter.
+ */
+public interface SentinelMetrics {
+
+    SentinelMetrics NOOP = new SentinelMetrics() {};
+
+    /** Final blended score after {@link io.aisentinel.core.scoring.CompositeScorer} aggregation. */
+    default void recordCompositeScore(double score) {}
+
+    /** Statistical (Welford) sub-score before blending. */
+    default void recordStatisticalScore(double score) {}
+
+    /** Isolation Forest sub-score (or fallback when no model). */
+    default void recordIsolationForestScore(double score) {}
+
+    default void recordPipelineLatencyNanos(long nanos) {}
+
+    /** Time spent in {@link io.aisentinel.core.scoring.AnomalyScorer#score} + {@code update} for the request. */
+    default void recordScoringLatencyNanos(long nanos) {}
+
+    /** IF model inference only (hot path inside {@link io.aisentinel.core.scoring.IsolationForestScorer#score}). */
+    default void recordIsolationForestInferenceLatencyNanos(long nanos) {}
+
+    /** Policy outcome applied (after grace / quarantine overrides). */
+    default void recordPolicyAction(EnforcementAction action) {}
+
+    /** Request allowed despite pipeline error (fail-open). */
+    default void recordFailOpen() {}
+
+    /** Illegal raw score corrected before policy (NaN or negative). */
+    default void recordNanOrNegativeScoreClamped() {}
+
+    /** Exception during scoring/update. */
+    default void recordScoringError() {}
+
+    default void recordRetrainSuccessNanos(long nanos) {}
+
+    default void recordRetrainFailureNanos(long nanos) {}
+}

--- a/ai-sentinel-core/src/main/java/io/aisentinel/core/scoring/CompositeScorer.java
+++ b/ai-sentinel-core/src/main/java/io/aisentinel/core/scoring/CompositeScorer.java
@@ -1,5 +1,6 @@
 package io.aisentinel.core.scoring;
 
+import io.aisentinel.core.metrics.SentinelMetrics;
 import io.aisentinel.core.model.RequestFeatures;
 
 import java.util.ArrayList;
@@ -12,6 +13,15 @@ import java.util.List;
 public final class CompositeScorer implements AnomalyScorer {
 
     private final List<WeightedScorer> scorers = new ArrayList<>();
+    private final SentinelMetrics metrics;
+
+    public CompositeScorer() {
+        this(SentinelMetrics.NOOP);
+    }
+
+    public CompositeScorer(SentinelMetrics metrics) {
+        this.metrics = metrics != null ? metrics : SentinelMetrics.NOOP;
+    }
 
     public void addScorer(AnomalyScorer scorer, double weight) {
         if (weight > 0) {
@@ -21,7 +31,10 @@ public final class CompositeScorer implements AnomalyScorer {
 
     @Override
     public double score(RequestFeatures features) {
-        if (scorers.isEmpty()) return 0.0;
+        if (scorers.isEmpty()) {
+            metrics.recordCompositeScore(0.0);
+            return 0.0;
+        }
         double sum = 0;
         double totalWeight = 0;
         for (WeightedScorer ws : scorers) {
@@ -29,10 +42,18 @@ public final class CompositeScorer implements AnomalyScorer {
             sum += s * ws.weight;
             totalWeight += ws.weight;
         }
-        if (totalWeight <= 0) return 0.0;
+        if (totalWeight <= 0) {
+            metrics.recordCompositeScore(0.0);
+            return 0.0;
+        }
         double raw = sum / totalWeight;
-        if (Double.isNaN(raw) || raw < 0) return 1.0;
-        return Math.min(1.0, raw);
+        if (Double.isNaN(raw) || raw < 0) {
+            metrics.recordCompositeScore(1.0);
+            return 1.0;
+        }
+        double out = Math.min(1.0, raw);
+        metrics.recordCompositeScore(out);
+        return out;
     }
 
     @Override

--- a/ai-sentinel-core/src/main/java/io/aisentinel/core/scoring/IsolationForestScorer.java
+++ b/ai-sentinel-core/src/main/java/io/aisentinel/core/scoring/IsolationForestScorer.java
@@ -1,5 +1,6 @@
 package io.aisentinel.core.scoring;
 
+import io.aisentinel.core.metrics.SentinelMetrics;
 import io.aisentinel.core.model.RequestFeatures;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -27,10 +28,16 @@ public final class IsolationForestScorer implements AnomalyScorer {
     private volatile long lastRetrainFailureTimeMillis;
     private final AtomicLong acceptedTrainingSampleCount = new AtomicLong(0);
     private final AtomicLong rejectedTrainingSampleCount = new AtomicLong(0);
+    private final SentinelMetrics metrics;
 
     public IsolationForestScorer(BoundedTrainingBuffer buffer, IsolationForestConfig config) {
+        this(buffer, config, SentinelMetrics.NOOP);
+    }
+
+    public IsolationForestScorer(BoundedTrainingBuffer buffer, IsolationForestConfig config, SentinelMetrics metrics) {
         this.buffer = buffer;
         this.config = config;
+        this.metrics = metrics != null ? metrics : SentinelMetrics.NOOP;
         this.trainer = new IsolationForestTrainer(
             config.getNumTrees(),
             config.getMaxDepth(),
@@ -40,12 +47,40 @@ public final class IsolationForestScorer implements AnomalyScorer {
 
     @Override
     public double score(RequestFeatures features) {
+        return evaluateScore(features, true);
+    }
+
+    /**
+     * @param recordRequestMetrics when true, records IF score histogram and inference latency (request path).
+     */
+    private double evaluateScore(RequestFeatures features, boolean recordRequestMetrics) {
         IsolationForestModel m = model;
-        if (m == null) return config.getFallbackScore();
+        if (m == null) {
+            double fb = config.getFallbackScore();
+            if (recordRequestMetrics) {
+                metrics.recordIsolationForestScore(fb);
+            }
+            return fb;
+        }
         double[] x = features.toArray();
+        long t0 = System.nanoTime();
         double s = m.score(x);
-        if (Double.isNaN(s) || s < 0) return config.getFallbackScore();
-        return Math.min(1.0, Math.max(0.0, s));
+        long infNanos = System.nanoTime() - t0;
+        if (recordRequestMetrics) {
+            metrics.recordIsolationForestInferenceLatencyNanos(infNanos);
+        }
+        if (Double.isNaN(s) || s < 0) {
+            double fb = config.getFallbackScore();
+            if (recordRequestMetrics) {
+                metrics.recordIsolationForestScore(fb);
+            }
+            return fb;
+        }
+        double out = Math.min(1.0, Math.max(0.0, s));
+        if (recordRequestMetrics) {
+            metrics.recordIsolationForestScore(out);
+        }
+        return out;
     }
 
     @Override
@@ -53,7 +88,7 @@ public final class IsolationForestScorer implements AnomalyScorer {
         if (config.getSampleRate() <= 0) return;
         IsolationForestModel m = model;
         if (m != null) {
-            double anomalyScore = score(features);
+            double anomalyScore = evaluateScore(features, false);
             double rejectionThreshold = config.getTrainingRejectionScoreThreshold();
             if (anomalyScore > rejectionThreshold) {
                 rejectedTrainingSampleCount.incrementAndGet();
@@ -74,6 +109,7 @@ public final class IsolationForestScorer implements AnomalyScorer {
         List<double[]> samples = buffer.getSnapshotForTraining();
         if (samples.size() < config.getMinTrainingSamples()) return;
         long startMs = System.currentTimeMillis();
+        long t0 = System.nanoTime();
         try {
             IsolationForestModel newModel = trainer.train(samples);
             if (newModel != null) {
@@ -82,11 +118,13 @@ public final class IsolationForestScorer implements AnomalyScorer {
                 lastRetrainTimeMillis = System.currentTimeMillis();
                 long durationMs = lastRetrainTimeMillis - startMs;
                 log.info("IF retrain v{} completed in {}ms using {} samples", v, durationMs, samples.size());
+                metrics.recordRetrainSuccessNanos(System.nanoTime() - t0);
             }
         } catch (Exception e) {
             retrainFailureCount.incrementAndGet();
             lastRetrainFailureTimeMillis = System.currentTimeMillis();
             log.warn("Isolation Forest retrain failed (request path unaffected): {}", e.getMessage());
+            metrics.recordRetrainFailureNanos(System.nanoTime() - t0);
         }
     }
 

--- a/ai-sentinel-core/src/main/java/io/aisentinel/core/scoring/StatisticalScorer.java
+++ b/ai-sentinel-core/src/main/java/io/aisentinel/core/scoring/StatisticalScorer.java
@@ -1,5 +1,6 @@
 package io.aisentinel.core.scoring;
 
+import io.aisentinel.core.metrics.SentinelMetrics;
 import io.aisentinel.core.model.RequestFeatures;
 
 import java.util.Map;
@@ -20,6 +21,7 @@ public final class StatisticalScorer implements AnomalyScorer {
     private final long ttlMs;
     private final int warmupMinSamples;
     private final double warmupScore;
+    private final SentinelMetrics metrics;
 
     public StatisticalScorer() {
         this(100_000, 300_000L, 2, 0.4);
@@ -30,10 +32,21 @@ public final class StatisticalScorer implements AnomalyScorer {
     }
 
     public StatisticalScorer(int maxKeys, long ttlMs, int warmupMinSamples, double warmupScore) {
+        this(maxKeys, ttlMs, warmupMinSamples, warmupScore, SentinelMetrics.NOOP);
+    }
+
+    public StatisticalScorer(int maxKeys, long ttlMs, int warmupMinSamples, double warmupScore,
+                             SentinelMetrics metrics) {
         this.maxKeys = Math.max(1, maxKeys);
         this.ttlMs = Math.max(1000L, ttlMs);
         this.warmupMinSamples = Math.max(0, warmupMinSamples);
         this.warmupScore = warmupScore < 0 ? 0 : Math.min(1.0, warmupScore);
+        this.metrics = metrics != null ? metrics : SentinelMetrics.NOOP;
+    }
+
+    /** Welford state map size (for cache gauges). */
+    public int metricsStateEntryCount() {
+        return stateByKey.size();
     }
 
     @Override
@@ -43,6 +56,7 @@ public final class StatisticalScorer implements AnomalyScorer {
 
         WelfordState state = stateByKey.get(key);
         if (state == null) {
+            metrics.recordStatisticalScore(warmupScore);
             return warmupScore;
         }
         double[] means;
@@ -50,7 +64,10 @@ public final class StatisticalScorer implements AnomalyScorer {
         int n;
         synchronized (state) {
             n = state.n;
-            if (n < Math.max(2, warmupMinSamples)) return warmupScore;
+            if (n < Math.max(2, warmupMinSamples)) {
+                metrics.recordStatisticalScore(warmupScore);
+                return warmupScore;
+            }
             means = state.getMeansCopy();
             stds = state.getStds();
         }
@@ -63,7 +80,9 @@ public final class StatisticalScorer implements AnomalyScorer {
             maxZ = Math.max(maxZ, z);
         }
         double s = sigmoid(maxZ);
-        return Double.isNaN(s) ? 1.0 : Math.min(1.0, Math.max(0.0, s));
+        double out = Double.isNaN(s) ? 1.0 : Math.min(1.0, Math.max(0.0, s));
+        metrics.recordStatisticalScore(out);
+        return out;
     }
 
     @Override

--- a/ai-sentinel-core/src/test/java/io/aisentinel/core/SentinelPipelineMetricsTest.java
+++ b/ai-sentinel-core/src/test/java/io/aisentinel/core/SentinelPipelineMetricsTest.java
@@ -1,0 +1,80 @@
+package io.aisentinel.core;
+
+import io.aisentinel.core.enforcement.EnforcementHandler;
+import io.aisentinel.core.feature.FeatureExtractor;
+import io.aisentinel.core.metrics.SentinelMetrics;
+import io.aisentinel.core.model.RequestContext;
+import io.aisentinel.core.model.RequestFeatures;
+import io.aisentinel.core.policy.EnforcementAction;
+import io.aisentinel.core.policy.PolicyEngine;
+import io.aisentinel.core.runtime.StartupGrace;
+import io.aisentinel.core.scoring.AnomalyScorer;
+import io.aisentinel.core.telemetry.TelemetryEmitter;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+class SentinelPipelineMetricsTest {
+
+    @Test
+    void scoringFailureIncrementsSafetyCounters() throws Exception {
+        FeatureExtractor extractor = mock(FeatureExtractor.class);
+        RequestFeatures features = RequestFeatures.builder()
+            .identityHash("h").endpoint("/api").timestampMillis(0)
+            .requestsPerWindow(1).endpointEntropy(0).tokenAgeSeconds(60)
+            .parameterCount(0).payloadSizeBytes(0).headerFingerprintHash(0).ipBucket(0).build();
+        when(extractor.extract(any(), eq("h"), any(RequestContext.class))).thenReturn(features);
+
+        AnomalyScorer badScorer = mock(AnomalyScorer.class);
+        when(badScorer.score(any())).thenThrow(new RuntimeException("boom"));
+
+        PolicyEngine policy = mock(PolicyEngine.class);
+        EnforcementHandler handler = mock(EnforcementHandler.class);
+        SentinelMetrics metrics = mock(SentinelMetrics.class);
+
+        SentinelPipeline pipeline = new SentinelPipeline(
+            extractor, badScorer, policy, handler, mock(TelemetryEmitter.class), StartupGrace.NEVER, metrics);
+
+        boolean proceed = pipeline.process(mock(HttpServletRequest.class), mock(HttpServletResponse.class), "h");
+
+        assertThat(proceed).isTrue();
+        verify(metrics).recordScoringError();
+        verify(metrics).recordFailOpen();
+        verify(metrics).recordScoringLatencyNanos(anyLong());
+        verify(metrics).recordPipelineLatencyNanos(anyLong());
+        verifyNoInteractions(handler);
+    }
+
+    @Test
+    void recordsPolicyActionBeforeApply() throws Exception {
+        FeatureExtractor extractor = mock(FeatureExtractor.class);
+        RequestFeatures features = RequestFeatures.builder()
+            .identityHash("h").endpoint("/api").timestampMillis(0)
+            .requestsPerWindow(1).endpointEntropy(0).tokenAgeSeconds(60)
+            .parameterCount(0).payloadSizeBytes(0).headerFingerprintHash(0).ipBucket(0).build();
+        when(extractor.extract(any(), eq("h"), any(RequestContext.class))).thenReturn(features);
+
+        AnomalyScorer scorer = mock(AnomalyScorer.class);
+        when(scorer.score(any())).thenReturn(0.05);
+
+        PolicyEngine policy = new io.aisentinel.core.policy.ThresholdPolicyEngine();
+        EnforcementHandler handler = mock(EnforcementHandler.class);
+        when(handler.isQuarantined(any(), any())).thenReturn(false);
+        when(handler.apply(eq(EnforcementAction.ALLOW), any(), any(), eq("h"), eq("/api"))).thenReturn(true);
+
+        SentinelMetrics metrics = mock(SentinelMetrics.class);
+        SentinelPipeline pipeline = new SentinelPipeline(
+            extractor, scorer, policy, handler, mock(TelemetryEmitter.class), StartupGrace.NEVER, metrics);
+
+        pipeline.process(mock(HttpServletRequest.class), mock(HttpServletResponse.class), "h");
+
+        verify(metrics).recordPolicyAction(EnforcementAction.ALLOW);
+        verify(metrics).recordPipelineLatencyNanos(anyLong());
+    }
+}

--- a/ai-sentinel-core/src/test/java/io/aisentinel/core/SentinelPipelineTest.java
+++ b/ai-sentinel-core/src/test/java/io/aisentinel/core/SentinelPipelineTest.java
@@ -4,6 +4,7 @@ import io.aisentinel.core.enforcement.EnforcementHandler;
 import io.aisentinel.core.feature.FeatureExtractor;
 import io.aisentinel.core.model.RequestContext;
 import io.aisentinel.core.model.RequestFeatures;
+import io.aisentinel.core.metrics.SentinelMetrics;
 import io.aisentinel.core.policy.EnforcementAction;
 import io.aisentinel.core.policy.PolicyEngine;
 import io.aisentinel.core.runtime.StartupGrace;
@@ -43,7 +44,7 @@ class SentinelPipelineTest {
         when(handler.isQuarantined(anyString(), anyString())).thenReturn(false);
         when(handler.apply(eq(EnforcementAction.QUARANTINE), any(), any(), eq("h"), eq("/api"))).thenReturn(false);
 
-        SentinelPipeline pipeline = new SentinelPipeline(extractor, nanScorer, policy, handler, mock(TelemetryEmitter.class), StartupGrace.NEVER);
+        SentinelPipeline pipeline = new SentinelPipeline(extractor, nanScorer, policy, handler, mock(TelemetryEmitter.class), StartupGrace.NEVER, SentinelMetrics.NOOP);
         HttpServletRequest request = mock(HttpServletRequest.class);
         HttpServletResponse response = mock(HttpServletResponse.class);
 
@@ -74,7 +75,7 @@ class SentinelPipelineTest {
         when(handler.apply(eq(EnforcementAction.MONITOR), any(), any(), eq("h"), eq("/api"))).thenReturn(true);
 
         StartupGrace grace = () -> true;
-        SentinelPipeline pipeline = new SentinelPipeline(extractor, nanScorer, policy, handler, mock(TelemetryEmitter.class), grace);
+        SentinelPipeline pipeline = new SentinelPipeline(extractor, nanScorer, policy, handler, mock(TelemetryEmitter.class), grace, SentinelMetrics.NOOP);
         HttpServletRequest request = mock(HttpServletRequest.class);
         HttpServletResponse response = mock(HttpServletResponse.class);
 
@@ -105,7 +106,7 @@ class SentinelPipelineTest {
         when(handler.isQuarantined(anyString(), anyString())).thenReturn(false);
         when(handler.apply(eq(EnforcementAction.QUARANTINE), any(), any(), eq("h"), eq("/api"))).thenReturn(false);
 
-        SentinelPipeline pipeline = new SentinelPipeline(extractor, negativeScorer, policy, handler, mock(TelemetryEmitter.class), StartupGrace.NEVER);
+        SentinelPipeline pipeline = new SentinelPipeline(extractor, negativeScorer, policy, handler, mock(TelemetryEmitter.class), StartupGrace.NEVER, SentinelMetrics.NOOP);
         HttpServletRequest request = mock(HttpServletRequest.class);
         HttpServletResponse response = mock(HttpServletResponse.class);
 

--- a/ai-sentinel-spring-boot-starter/src/main/java/io/aisentinel/autoconfigure/actuator/SentinelActuatorEndpoint.java
+++ b/ai-sentinel-spring-boot-starter/src/main/java/io/aisentinel/autoconfigure/actuator/SentinelActuatorEndpoint.java
@@ -1,6 +1,7 @@
 package io.aisentinel.autoconfigure.actuator;
 
 import io.aisentinel.autoconfigure.config.SentinelProperties;
+import io.aisentinel.autoconfigure.metrics.MicrometerSentinelMetrics;
 import io.aisentinel.core.enforcement.CompositeEnforcementHandler;
 import io.aisentinel.core.runtime.StartupGrace;
 import io.aisentinel.core.scoring.IsolationForestScorer;
@@ -19,15 +20,18 @@ public class SentinelActuatorEndpoint {
     private final CompositeEnforcementHandler enforcementHandlerImpl;
     private final IsolationForestScorer isolationForestScorer;
     private final StartupGrace startupGrace;
+    private final MicrometerSentinelMetrics micrometerSentinelMetrics;
 
     public SentinelActuatorEndpoint(SentinelProperties props,
                                     CompositeEnforcementHandler enforcementHandlerImpl,
                                     IsolationForestScorer isolationForestScorer,
-                                    StartupGrace startupGrace) {
+                                    StartupGrace startupGrace,
+                                    MicrometerSentinelMetrics micrometerSentinelMetrics) {
         this.props = props;
         this.enforcementHandlerImpl = enforcementHandlerImpl;
         this.isolationForestScorer = isolationForestScorer;
         this.startupGrace = startupGrace != null ? startupGrace : StartupGrace.NEVER;
+        this.micrometerSentinelMetrics = micrometerSentinelMetrics;
     }
 
     @ReadOperation
@@ -55,6 +59,12 @@ public class SentinelActuatorEndpoint {
         } else {
             map.put("acceptedTrainingSampleCount", 0L);
             map.put("rejectedTrainingSampleCount", 0L);
+        }
+        if (micrometerSentinelMetrics != null) {
+            map.put("scoreSummary", micrometerSentinelMetrics.scoreSummaryForActuator());
+            map.put("latencySummary", micrometerSentinelMetrics.latencySummaryForActuator());
+            map.put("modelRetrainSuccessCount", micrometerSentinelMetrics.getRetrainSuccessCount());
+            map.put("modelRetrainFailureCount", micrometerSentinelMetrics.getRetrainFailureCount());
         }
         return map;
     }

--- a/ai-sentinel-spring-boot-starter/src/main/java/io/aisentinel/autoconfigure/actuator/SentinelEndpointAutoConfiguration.java
+++ b/ai-sentinel-spring-boot-starter/src/main/java/io/aisentinel/autoconfigure/actuator/SentinelEndpointAutoConfiguration.java
@@ -1,6 +1,7 @@
 package io.aisentinel.autoconfigure.actuator;
 
 import io.aisentinel.autoconfigure.config.SentinelProperties;
+import io.aisentinel.autoconfigure.metrics.MicrometerSentinelMetrics;
 import io.aisentinel.core.enforcement.CompositeEnforcementHandler;
 import io.aisentinel.core.runtime.StartupGrace;
 import io.aisentinel.core.scoring.IsolationForestScorer;
@@ -30,9 +31,10 @@ public class SentinelEndpointAutoConfiguration {
     public SentinelActuatorEndpoint sentinelActuatorEndpoint(SentinelProperties props,
                                                             CompositeEnforcementHandler enforcementHandlerImpl,
                                                             ObjectProvider<IsolationForestScorer> isolationForestScorerProvider,
-                                                            ObjectProvider<StartupGrace> startupGraceProvider) {
+                                                            ObjectProvider<StartupGrace> startupGraceProvider,
+                                                            ObjectProvider<MicrometerSentinelMetrics> micrometerSentinelMetricsProvider) {
         log.debug("Registering Sentinel actuator endpoint");
         return new SentinelActuatorEndpoint(props, enforcementHandlerImpl, isolationForestScorerProvider.getIfAvailable(),
-            startupGraceProvider.getIfAvailable());
+            startupGraceProvider.getIfAvailable(), micrometerSentinelMetricsProvider.getIfAvailable());
     }
 }

--- a/ai-sentinel-spring-boot-starter/src/main/java/io/aisentinel/autoconfigure/config/SentinelAutoConfiguration.java
+++ b/ai-sentinel-spring-boot-starter/src/main/java/io/aisentinel/autoconfigure/config/SentinelAutoConfiguration.java
@@ -14,10 +14,12 @@ import io.aisentinel.core.scoring.IsolationForestConfig;
 import io.aisentinel.core.scoring.IsolationForestScorer;
 import io.aisentinel.core.scoring.StatisticalScorer;
 import io.aisentinel.core.store.BaselineStore;
+import io.aisentinel.core.metrics.SentinelMetrics;
 import io.aisentinel.core.telemetry.DefaultTelemetryEmitter;
 import io.aisentinel.core.runtime.StartupGrace;
 import io.aisentinel.core.telemetry.TelemetryConfig;
 import io.aisentinel.core.telemetry.TelemetryEmitter;
+import io.aisentinel.autoconfigure.metrics.MicrometerSentinelMetrics;
 import io.aisentinel.autoconfigure.web.SentinelFilter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.binder.MeterBinder;
@@ -31,18 +33,24 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 
-import jakarta.annotation.PostConstruct;
-import jakarta.annotation.PreDestroy;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
-
 @Slf4j
 @AutoConfiguration
 @ConditionalOnWebApplication
 @ConditionalOnProperty(name = "ai.sentinel.enabled", havingValue = "true", matchIfMissing = true)
 @EnableConfigurationProperties(SentinelProperties.class)
 public class SentinelAutoConfiguration {
+
+    @Bean
+    @ConditionalOnBean(MeterRegistry.class)
+    public SentinelMetrics sentinelMetrics(MeterRegistry registry) {
+        return new MicrometerSentinelMetrics(registry);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean(SentinelMetrics.class)
+    public SentinelMetrics noopSentinelMetrics() {
+        return SentinelMetrics.NOOP;
+    }
 
     @Bean
     @ConditionalOnMissingBean
@@ -61,12 +69,12 @@ public class SentinelAutoConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
-    public StatisticalScorer statisticalScorer(SentinelProperties props) {
+    public StatisticalScorer statisticalScorer(SentinelProperties props, SentinelMetrics sentinelMetrics) {
         int maxKeys = props.getInternalMapMaxKeys() > 0 ? props.getInternalMapMaxKeys() : 100_000;
         long ttlMs = props.getInternalMapTtl() != null ? props.getInternalMapTtl().toMillis() : 300_000L;
         int warmupMin = props.getWarmupMinSamples() >= 0 ? props.getWarmupMinSamples() : 2;
         double warmupScore = props.getWarmupScore() < 0 ? 0.4 : Math.min(1.0, props.getWarmupScore());
-        return new StatisticalScorer(maxKeys, ttlMs, warmupMin, warmupScore);
+        return new StatisticalScorer(maxKeys, ttlMs, warmupMin, warmupScore, sentinelMetrics);
     }
 
     @Bean
@@ -107,17 +115,30 @@ public class SentinelAutoConfiguration {
     @Bean
     @ConditionalOnMissingBean
     public IsolationForestScorer isolationForestScorer(BoundedTrainingBuffer isolationForestTrainingBuffer,
-                                                      IsolationForestConfig isolationForestConfig) {
-        return new IsolationForestScorer(isolationForestTrainingBuffer, isolationForestConfig);
+                                                      IsolationForestConfig isolationForestConfig,
+                                                      SentinelMetrics sentinelMetrics) {
+        return new IsolationForestScorer(isolationForestTrainingBuffer, isolationForestConfig, sentinelMetrics);
     }
 
     @Bean
-    public MeterBinder sentinelTrainingSampleMetrics(IsolationForestScorer isolationForestScorer) {
+    @ConditionalOnBean(MeterRegistry.class)
+    public MeterBinder aisentinelSystemAndTrainingGauges(StatisticalScorer statisticalScorer,
+                                                         FeatureExtractor featureExtractor,
+                                                         CompositeEnforcementHandler enforcementHandlerImpl,
+                                                         IsolationForestScorer isolationForestScorer) {
         return registry -> {
             registry.gauge("aisentinel.training.samples.accepted", isolationForestScorer,
                 s -> (double) s.getAcceptedTrainingSampleCount());
             registry.gauge("aisentinel.training.samples.rejected", isolationForestScorer,
                 s -> (double) s.getRejectedTrainingSampleCount());
+            registry.gauge("aisentinel.cache.state.size", statisticalScorer,
+                s -> (double) s.metricsStateEntryCount());
+            registry.gauge("aisentinel.cache.endpointHistory.size", featureExtractor,
+                f -> (double) f.metricsEndpointHistoryEntryCount());
+            registry.gauge("aisentinel.cache.throttle.size", enforcementHandlerImpl,
+                h -> (double) h.getThrottleCount());
+            registry.gauge("aisentinel.cache.quarantine.size", enforcementHandlerImpl,
+                h -> (double) h.getQuarantineCount());
         };
     }
 
@@ -125,8 +146,9 @@ public class SentinelAutoConfiguration {
     @ConditionalOnMissingBean
     public CompositeScorer compositeScorer(StatisticalScorer statisticalScorer,
                                            IsolationForestScorer isolationForestScorer,
-                                           SentinelProperties props) {
-        var composite = new CompositeScorer();
+                                           SentinelProperties props,
+                                           SentinelMetrics sentinelMetrics) {
+        var composite = new CompositeScorer(sentinelMetrics);
         composite.addScorer(statisticalScorer, 1.0);
         if (props.getIsolationForest().isEnabled()) {
             double weight = props.getIsolationForest().getScoreWeight();
@@ -204,6 +226,7 @@ public class SentinelAutoConfiguration {
                                              EnforcementHandler enforcementHandler,
                                              TelemetryEmitter telemetry,
                                              StartupGrace sentinelStartupGrace,
+                                             SentinelMetrics sentinelMetrics,
                                              SentinelProperties props) {
         log.info("Sentinel pipeline configured (mode={})", props.getMode());
         return new SentinelPipeline(
@@ -212,13 +235,14 @@ public class SentinelAutoConfiguration {
             policyEngine,
             enforcementHandler,
             telemetry,
-            sentinelStartupGrace
+            sentinelStartupGrace,
+            sentinelMetrics
         );
     }
 
     @Bean
     @ConditionalOnMissingBean
-    public SentinelFilter sentinelFilter(SentinelPipeline pipeline, SentinelProperties props) {
-        return new SentinelFilter(pipeline, props);
+    public SentinelFilter sentinelFilter(SentinelPipeline pipeline, SentinelProperties props, SentinelMetrics sentinelMetrics) {
+        return new SentinelFilter(pipeline, props, sentinelMetrics);
     }
 }

--- a/ai-sentinel-spring-boot-starter/src/main/java/io/aisentinel/autoconfigure/metrics/MicrometerSentinelMetrics.java
+++ b/ai-sentinel-spring-boot-starter/src/main/java/io/aisentinel/autoconfigure/metrics/MicrometerSentinelMetrics.java
@@ -1,0 +1,222 @@
+package io.aisentinel.autoconfigure.metrics;
+
+import io.aisentinel.core.policy.EnforcementAction;
+import io.aisentinel.core.metrics.SentinelMetrics;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.DistributionSummary;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Micrometer-backed {@link SentinelMetrics}. Registers meters once; recording is lightweight.
+ */
+public final class MicrometerSentinelMetrics implements SentinelMetrics {
+
+    private final DistributionSummary scoreComposite;
+    private final DistributionSummary scoreIf;
+    private final DistributionSummary scoreStatistical;
+
+    private final Counter actionAllow;
+    private final Counter actionMonitor;
+    private final Counter actionThrottle;
+    private final Counter actionBlock;
+    private final Counter actionQuarantine;
+
+    private final Timer latencyPipeline;
+    private final Timer latencyScoring;
+    private final Timer latencyIf;
+
+    private final Timer modelRetrainDuration;
+    private final Counter modelRetrainSuccess;
+    private final Counter modelRetrainFailure;
+
+    private final Counter failOpen;
+    private final Counter nanClamped;
+    private final Counter scoringErrors;
+
+    public MicrometerSentinelMetrics(MeterRegistry registry) {
+        this.scoreComposite = DistributionSummary.builder("aisentinel.score.composite")
+            .description("Blended anomaly score after composite weighting")
+            .publishPercentiles(0.5, 0.9, 0.99)
+            .register(registry);
+        this.scoreIf = DistributionSummary.builder("aisentinel.score.if")
+            .description("Isolation Forest (or fallback) score contribution")
+            .publishPercentiles(0.5, 0.9, 0.99)
+            .register(registry);
+        this.scoreStatistical = DistributionSummary.builder("aisentinel.score.statistical")
+            .description("Statistical scorer output")
+            .publishPercentiles(0.5, 0.9, 0.99)
+            .register(registry);
+
+        this.actionAllow = Counter.builder("aisentinel.action.allow").register(registry);
+        this.actionMonitor = Counter.builder("aisentinel.action.monitor").register(registry);
+        this.actionThrottle = Counter.builder("aisentinel.action.throttle").register(registry);
+        this.actionBlock = Counter.builder("aisentinel.action.block").register(registry);
+        this.actionQuarantine = Counter.builder("aisentinel.action.quarantine").register(registry);
+
+        this.latencyPipeline = Timer.builder("aisentinel.latency.pipeline")
+            .description("End-to-end Sentinel pipeline latency")
+            .publishPercentiles(0.5, 0.99)
+            .register(registry);
+        this.latencyScoring = Timer.builder("aisentinel.latency.scoring")
+            .description("Scorer score + update latency")
+            .publishPercentiles(0.5, 0.99)
+            .register(registry);
+        this.latencyIf = Timer.builder("aisentinel.latency.if")
+            .description("Isolation Forest inference latency")
+            .publishPercentiles(0.5, 0.99)
+            .register(registry);
+
+        this.modelRetrainDuration = Timer.builder("aisentinel.model.retrain.duration")
+            .description("Isolation Forest retrain duration")
+            .register(registry);
+        this.modelRetrainSuccess = Counter.builder("aisentinel.model.retrain.success").register(registry);
+        this.modelRetrainFailure = Counter.builder("aisentinel.model.retrain.failure").register(registry);
+
+        this.failOpen = Counter.builder("aisentinel.failopen.count").register(registry);
+        this.nanClamped = Counter.builder("aisentinel.nan.clamped.count").register(registry);
+        this.scoringErrors = Counter.builder("aisentinel.errors.scoring.count").register(registry);
+    }
+
+    @Override
+    public void recordCompositeScore(double score) {
+        if (!Double.isNaN(score) && score >= 0) {
+            scoreComposite.record(score);
+        }
+    }
+
+    @Override
+    public void recordStatisticalScore(double score) {
+        if (!Double.isNaN(score) && score >= 0) {
+            scoreStatistical.record(score);
+        }
+    }
+
+    @Override
+    public void recordIsolationForestScore(double score) {
+        if (!Double.isNaN(score) && score >= 0) {
+            scoreIf.record(score);
+        }
+    }
+
+    @Override
+    public void recordPipelineLatencyNanos(long nanos) {
+        if (nanos >= 0) {
+            latencyPipeline.record(nanos, TimeUnit.NANOSECONDS);
+        }
+    }
+
+    @Override
+    public void recordScoringLatencyNanos(long nanos) {
+        if (nanos >= 0) {
+            latencyScoring.record(nanos, TimeUnit.NANOSECONDS);
+        }
+    }
+
+    @Override
+    public void recordIsolationForestInferenceLatencyNanos(long nanos) {
+        if (nanos >= 0) {
+            latencyIf.record(nanos, TimeUnit.NANOSECONDS);
+        }
+    }
+
+    @Override
+    public void recordPolicyAction(EnforcementAction action) {
+        switch (action) {
+            case ALLOW -> actionAllow.increment();
+            case MONITOR -> actionMonitor.increment();
+            case THROTTLE -> actionThrottle.increment();
+            case BLOCK -> actionBlock.increment();
+            case QUARANTINE -> actionQuarantine.increment();
+        }
+    }
+
+    @Override
+    public void recordFailOpen() {
+        failOpen.increment();
+    }
+
+    @Override
+    public void recordNanOrNegativeScoreClamped() {
+        nanClamped.increment();
+    }
+
+    @Override
+    public void recordScoringError() {
+        scoringErrors.increment();
+    }
+
+    @Override
+    public void recordRetrainSuccessNanos(long nanos) {
+        if (nanos >= 0) {
+            modelRetrainDuration.record(nanos, TimeUnit.NANOSECONDS);
+        }
+        modelRetrainSuccess.increment();
+    }
+
+    @Override
+    public void recordRetrainFailureNanos(long nanos) {
+        if (nanos >= 0) {
+            modelRetrainDuration.record(nanos, TimeUnit.NANOSECONDS);
+        }
+        modelRetrainFailure.increment();
+    }
+
+    public Map<String, Object> scoreSummaryForActuator() {
+        Map<String, Object> m = new LinkedHashMap<>();
+        putSummary(m, "composite", scoreComposite);
+        putSummary(m, "statistical", scoreStatistical);
+        putSummary(m, "if", scoreIf);
+        return m;
+    }
+
+    public Map<String, Object> latencySummaryForActuator() {
+        Map<String, Object> m = new LinkedHashMap<>();
+        putTimer(m, "pipeline", latencyPipeline);
+        putTimer(m, "scoring", latencyScoring);
+        putTimer(m, "if", latencyIf);
+        return m;
+    }
+
+    public long getRetrainSuccessCount() {
+        return (long) modelRetrainSuccess.count();
+    }
+
+    public long getRetrainFailureCount() {
+        return (long) modelRetrainFailure.count();
+    }
+
+    private static void putSummary(Map<String, Object> out, String key, DistributionSummary summary) {
+        var snap = summary.takeSnapshot();
+        Map<String, Object> row = new LinkedHashMap<>();
+        row.put("count", snap.count());
+        if (snap.count() > 0) {
+            row.put("mean", snap.mean());
+            for (var pv : snap.percentileValues()) {
+                double p = pv.percentile();
+                if (Math.abs(p - 0.5) < 1e-6) row.put("p50", pv.value());
+                else if (Math.abs(p - 0.9) < 1e-6) row.put("p90", pv.value());
+                else if (Math.abs(p - 0.99) < 1e-6) row.put("p99", pv.value());
+            }
+        }
+        out.put(key, row);
+    }
+
+    private static void putTimer(Map<String, Object> out, String key, Timer timer) {
+        var snap = timer.takeSnapshot();
+        Map<String, Object> row = new LinkedHashMap<>();
+        row.put("count", snap.count());
+        if (snap.count() > 0) {
+            for (var pv : snap.percentileValues()) {
+                double p = pv.percentile();
+                if (Math.abs(p - 0.5) < 1e-6) row.put("p50Ms", pv.value(TimeUnit.MILLISECONDS));
+                else if (Math.abs(p - 0.99) < 1e-6) row.put("p99Ms", pv.value(TimeUnit.MILLISECONDS));
+            }
+        }
+        out.put(key, row);
+    }
+}

--- a/ai-sentinel-spring-boot-starter/src/main/java/io/aisentinel/autoconfigure/web/SentinelFilter.java
+++ b/ai-sentinel-spring-boot-starter/src/main/java/io/aisentinel/autoconfigure/web/SentinelFilter.java
@@ -2,6 +2,7 @@ package io.aisentinel.autoconfigure.web;
 
 import io.aisentinel.autoconfigure.config.SentinelProperties;
 import io.aisentinel.core.SentinelPipeline;
+import io.aisentinel.core.metrics.SentinelMetrics;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -25,6 +26,7 @@ public class SentinelFilter extends OncePerRequestFilter {
 
     private final SentinelPipeline pipeline;
     private final SentinelProperties props;
+    private final SentinelMetrics metrics;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
@@ -56,6 +58,7 @@ public class SentinelFilter extends OncePerRequestFilter {
             filterChain.doFilter(request, response);
         } catch (Exception e) {
             log.warn("Sentinel pipeline error for path={}, allowing request: {}", request.getRequestURI(), e.getMessage());
+            metrics.recordFailOpen();
             filterChain.doFilter(request, response);
         }
     }

--- a/ai-sentinel-spring-boot-starter/src/test/java/io/aisentinel/autoconfigure/actuator/SentinelActuatorEndpointTest.java
+++ b/ai-sentinel-spring-boot-starter/src/test/java/io/aisentinel/autoconfigure/actuator/SentinelActuatorEndpointTest.java
@@ -23,7 +23,7 @@ class SentinelActuatorEndpointTest {
     @Test
     void infoReturnsExpectedStructure() {
         SentinelProperties props = new SentinelProperties();
-        SentinelActuatorEndpoint endpoint = new SentinelActuatorEndpoint(props, compositeHandler(), null, StartupGrace.NEVER);
+        SentinelActuatorEndpoint endpoint = new SentinelActuatorEndpoint(props, compositeHandler(), null, StartupGrace.NEVER, null);
 
         Map<String, Object> info = endpoint.info();
 
@@ -42,7 +42,7 @@ class SentinelActuatorEndpointTest {
         props.setEnabled(false);
         props.setMode(SentinelProperties.Mode.MONITOR);
         props.getIsolationForest().setEnabled(true);
-        SentinelActuatorEndpoint endpoint = new SentinelActuatorEndpoint(props, compositeHandler(), null, StartupGrace.NEVER);
+        SentinelActuatorEndpoint endpoint = new SentinelActuatorEndpoint(props, compositeHandler(), null, StartupGrace.NEVER, null);
 
         Map<String, Object> info = endpoint.info();
 
@@ -59,7 +59,7 @@ class SentinelActuatorEndpointTest {
         var buffer = new BoundedTrainingBuffer(100);
         var config = new IsolationForestConfig(0.5, 10, 5, 5, 42L, 0.1);
         IsolationForestScorer ifScorer = new IsolationForestScorer(buffer, config);
-        SentinelActuatorEndpoint endpoint = new SentinelActuatorEndpoint(props, compositeHandler(), ifScorer, StartupGrace.NEVER);
+        SentinelActuatorEndpoint endpoint = new SentinelActuatorEndpoint(props, compositeHandler(), ifScorer, StartupGrace.NEVER, null);
 
         Map<String, Object> info = endpoint.info();
 

--- a/ai-sentinel-spring-boot-starter/src/test/java/io/aisentinel/autoconfigure/metrics/MicrometerSentinelMetricsTest.java
+++ b/ai-sentinel-spring-boot-starter/src/test/java/io/aisentinel/autoconfigure/metrics/MicrometerSentinelMetricsTest.java
@@ -1,0 +1,44 @@
+package io.aisentinel.autoconfigure.metrics;
+
+import io.aisentinel.core.policy.EnforcementAction;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class MicrometerSentinelMetricsTest {
+
+    @Test
+    void registersExpectedMetersAndIncrementsCounters() {
+        MeterRegistry registry = new SimpleMeterRegistry();
+        MicrometerSentinelMetrics m = new MicrometerSentinelMetrics(registry);
+
+        m.recordCompositeScore(0.42);
+        m.recordStatisticalScore(0.4);
+        m.recordIsolationForestScore(0.5);
+        m.recordPolicyAction(EnforcementAction.ALLOW);
+        m.recordFailOpen();
+        m.recordNanOrNegativeScoreClamped();
+        m.recordScoringError();
+        m.recordPipelineLatencyNanos(1_000_000L);
+        m.recordScoringLatencyNanos(500_000L);
+        m.recordIsolationForestInferenceLatencyNanos(100_000L);
+        m.recordRetrainSuccessNanos(2_000_000L);
+        m.recordRetrainFailureNanos(1_000_000L);
+
+        assertThat(registry.find("aisentinel.score.composite").summary().count()).isEqualTo(1L);
+        assertThat(registry.find("aisentinel.action.allow").counter().count()).isEqualTo(1.0);
+        assertThat(registry.find("aisentinel.failopen.count").counter().count()).isEqualTo(1.0);
+        assertThat(registry.find("aisentinel.nan.clamped.count").counter().count()).isEqualTo(1.0);
+        assertThat(registry.find("aisentinel.errors.scoring.count").counter().count()).isEqualTo(1.0);
+        assertThat(registry.find("aisentinel.latency.pipeline").timer().count()).isEqualTo(1L);
+        assertThat(registry.find("aisentinel.model.retrain.success").counter().count()).isEqualTo(1.0);
+        assertThat(registry.find("aisentinel.model.retrain.failure").counter().count()).isEqualTo(1.0);
+        assertThat(m.getRetrainSuccessCount()).isEqualTo(1L);
+        assertThat(m.getRetrainFailureCount()).isEqualTo(1L);
+
+        assertThat(m.scoreSummaryForActuator()).containsKeys("composite", "statistical", "if");
+        assertThat(m.latencySummaryForActuator()).containsKeys("pipeline", "scoring", "if");
+    }
+}


### PR DESCRIPTION
## Summary
Delivers **Stage 4 — Observability & SRE maturity** for AI-Sentinel: production-oriented metrics for scores, policy actions, latency, model retrain health, internal cache sizes, and fail-open / safety signals, without pulling Spring or Micrometer into `ai-sentinel-core`.

## Approach
- **`SentinelMetrics`** (core): small hook interface with default no-ops so the hot path stays optional and allocation-light.
- **`MicrometerSentinelMetrics`** (starter): registers Micrometer `DistributionSummary`, `Timer`, `Counter`, and connects them to the core hooks.
- **Wiring** (starter): conditional `SentinelMetrics` bean when `MeterRegistry` exists; otherwise a no-op implementation. Gauges for training samples and cache sizes via a `MeterBinder`.

## What was added

### Score metrics (distribution summaries, percentiles for actuator)
- `aisentinel.score.composite`
- `aisentinel.score.statistical`
- `aisentinel.score.if`

Recorded from `CompositeScorer`, `StatisticalScorer`, and `IsolationForestScorer` respectively.

### Action metrics (counters)
- `aisentinel.action.allow` | `.monitor` | `.throttle` | `.block` | `.quarantine`

Recorded in `SentinelPipeline` for the **final** policy action (after startup grace and quarantine overrides), before `enforcementHandler.apply`.

### Latency metrics (timers)
- `aisentinel.latency.pipeline` — full `SentinelPipeline.process`
- `aisentinel.latency.scoring` — `score` + `update` for the request
- `aisentinel.latency.if` — IF model inference only (public `score` path; training `update` uses a non-recording path to avoid double-counting)

### Model retrain metrics
- `aisentinel.model.retrain.duration` (timer)
- `aisentinel.model.retrain.success` / `aisentinel.model.retrain.failure` (counters)

Recorded from `IsolationForestScorer.retrain()`.

### Training & system metrics (gauges)
- `aisentinel.training.samples.accepted` / `.rejected` (existing names, still bound)
- `aisentinel.cache.state.size` — statistical Welford map (`StatisticalScorer.metricsStateEntryCount`)
- `aisentinel.cache.endpointHistory.size` — `FeatureExtractor.metricsEndpointHistoryEntryCount()`
- `aisentinel.cache.throttle.size` / `aisentinel.cache.quarantine.size` — enforcement handler maps

### Safety metrics (counters)
- `aisentinel.failopen.count` — extract/scoring failures and unexpected errors in `SentinelFilter`
- `aisentinel.nan.clamped.count` — NaN or negative raw score before clamp
- `aisentinel.errors.scoring.count` — exceptions in score/update

### Actuator (`/actuator/sentinel`)
When `MicrometerSentinelMetrics` is present:
- `scoreSummary` — mean, p50, p90, p99 (per composite / statistical / if, when data exists)
- `latencySummary` — p50/p99 ms for pipeline, scoring, IF
- `modelRetrainSuccessCount` / `modelRetrainFailureCount` — Micrometer counter totals

## Tests
- `MicrometerSentinelMetricsTest` — meters register and record as expected
- `SentinelPipelineMetricsTest` — pipeline invokes safety and policy metrics hooks
- Existing tests updated for new `SentinelPipeline` / actuator constructor parameters

## Constraints respected
- No blocking on the request path; recording is O(1) Micrometer updates.
- Core module remains free of Spring/Micrometer dependencies.
- Metrics implementation and binding live in the starter.