### PR TITLE
Pre–Stage 5: configurable policy thresholds, safe X-Real-IP, IF feature vector cleanup

### DIFF
--- a/IMPLEMENTATION_STATUS.md
+++ b/IMPLEMENTATION_STATUS.md
@@ -26,7 +26,7 @@ The project follows a staged roadmap: **Stage 0** (core engine) → **Stage 1** 
 | Stage | Name | Status | Notes |
 |-------|------|--------|--------|
 | **0** | Core Engine Foundation | **Complete** | FeatureExtractor, StatisticalScorer (Welford), warmup, ThresholdPolicyEngine, enforcement (Composite + MonitorOnly), CompositeScorer, TelemetryEmitter, bounded maps (TTL + maxKeys), concurrency fixes, unit + concurrency tests. Deterministic scoring, thread-safe state, no unbounded maps. |
-| **1** | Spring Boot Operational Integration | **Complete** | AutoConfiguration, SentinelFilter, application config (enabled, mode, warmup, trusted-proxies, map sizes/TTL, telemetry). Actuator endpoint with quarantineCount. Fail-open, MONITOR/ENFORCE. Gaps: policy thresholds not in config (D4), filter order fixed (D6), actuator cache sizes not yet (D8 partial). |
+| **1** | Spring Boot Operational Integration | **Complete** | AutoConfiguration, SentinelFilter, application config (enabled, mode, warmup, trusted-proxies, policy thresholds, map sizes/TTL, telemetry). Actuator endpoint with quarantineCount. Fail-open, MONITOR/ENFORCE. Remaining gaps: filter order fixed (D6), actuator cache sizes not yet (D8 partial). |
 | **2** | Real ML Integration | **In progress** | Bounded training buffer, minimal in-core Isolation Forest (fixed seed, path-length score), IsolationForestScorer with fallback when no model, async retrain via scheduler, actuator metadata (lastRetrainTime, modelVersion, bufferedSampleCount, modelLoaded). Config: training-buffer-size, min-training-samples, retrain-interval, random-seed, score-weight, sample-rate, fallback-score. Inference lock-free; training failures do not affect request path. |
 | **3** | Security Hardening & Adversarial Defense | **Partial** | Proxy trust (trusted-proxies, X-Forwarded-For / Forwarded / X-Real-IP) done. CIDR not supported (exact IP list only). Per-endpoint quarantine (E4), poisoning resistance, gradual enforcement ramp, 5k RPS stress tests — not done. |
 | **4** | Observability & SRE Maturity | **Partial** | Micrometer counters, JSON logging, actuator basic info. Missing: score histograms, cache/eviction metrics, scoring latency p95/p99, fail-open counters, OpenTelemetry. |
@@ -62,7 +62,7 @@ Build: Maven multi-module (root `pom.xml`). Run demo: `mvn -pl ai-sentinel-demo 
 ### 4.2 Spring Boot integration
 
 - **Filter** — `SentinelFilter`: identity resolution (IP + optional Spring Security principal), pipeline invocation, exclude paths, MONITOR vs ENFORCE.
-- **Configuration** — `SentinelProperties`: enabled, mode, excludePaths, blockStatusCode, quarantineDurationMs, throttleRequestsPerSecond, baselineTtl, baselineMaxKeys, internalMapMaxKeys, internalMapTtl, trustedProxies, warmupMinSamples, warmupScore, isolationForest, telemetry.
+- **Configuration** — `SentinelProperties`: enabled, mode, excludePaths, blockStatusCode, quarantineDurationMs, throttleRequestsPerSecond, baselineTtl, baselineMaxKeys, internalMapMaxKeys, internalMapTtl, trustedProxies, threshold-moderate / threshold-elevated / threshold-high / threshold-critical, warmupMinSamples, warmupScore, isolationForest, telemetry.
 - **Actuator** — `/actuator/sentinel`: enabled, mode, isolationForestEnabled, quarantineCount; when IF enabled also **isolationForestModelLoaded**, **isolationForestBufferedSampleCount**, **isolationForestModelVersion**, **isolationForestLastRetrainTimeMillis**, **isolationForestModelAgeMillis**, **isolationForestRetrainFailureCount**, **isolationForestLastRetrainFailureTimeMillis**.
 
 #### Stage 2.2 — Operational Hardening
@@ -82,13 +82,19 @@ Addressed items from the production review and audit:
 | Area | What was done |
 |------|----------------|
 | **Concurrency / data races** | A1/C1: `StatisticalScorer` — `score()` and `update()` use same lock on `WelfordState`; reads via `getMeansCopy()` / `getStds()` under lock. C4: `CompositeEnforcementHandler.isQuarantined()` uses `quarantinedUntil.compute()` for atomic check-and-remove (no TOCTOU). |
-| **Proxy identity** | A5: `SentinelFilter.resolveClientIp(request, trustedProxies)` — when remote is in trusted list, client IP from X-Forwarded-For (leftmost), Forwarded `for=`, or X-Real-IP. Config: `ai.sentinel.trusted-proxies`. |
+| **Proxy identity** | A5: `ClientIpResolver` / `SentinelFilter` — when remote is trusted, client IP from X-Forwarded-For (rightmost-untrusted), then Forwarded `for=`, then X-Real-IP only if there is no forward-chain hint (no non-blank X-Forwarded-For or Forwarded header). Config: `ai.sentinel.trusted-proxies`. |
 | **Map growth / OOM** | A4: All four maps bounded: `stateByKey`, `endpointHistory`, `throttleTokens`, `quarantinedUntil` use maxKeys + TTL/expiry; eviction in StatisticalScorer, DefaultFeatureExtractor, CompositeEnforcementHandler. Config: `internalMapMaxKeys`, `internalMapTtl`. |
 | **Endpoint history** | A2: Atomic counters (`AtomicIntegerArray`) and saturation at `MAX_HISTORY_COUNT` to avoid overflow/NaN. A3: `safeHistoryIndex()` — no `Math.abs(Integer.MIN_VALUE)`; index in [0, HISTORY_SIZE). |
 | **NaN / bypass** | A6: NaN and negative scores clamped to high risk: `SentinelPipeline.clampScore()`, `CompositeScorer`, `StatisticalScorer` (z/sigmoid NaN handling). Policy then sees 1.0 → no ALLOW bypass. |
 | **Cold start** | D3: `StatisticalScorer` warmup — when state is null or `n < warmupMinSamples`, return `warmupScore` (default 0.4) instead of 0.0. Config: `warmupMinSamples`, `warmupScore`. |
 | **Path parameter explosion** | E2: `DefaultFeatureExtractor.normalizeEndpoint()` — truncate to 256 chars; `normalizePathParams()` replaces numeric and UUID path segments with `{id}` so `/api/users/123` and `/api/users/456` share one baseline. |
 | **Monitor visibility** | A7: `MonitorOnlyEnforcementHandler.isQuarantined()` delegates to delegate; actuator `info()` exposes `quarantineCount` from `CompositeEnforcementHandler.getQuarantineCount()`. |
+
+### 4.4 Pre-Stage 5 Critical Fixes
+
+- **Configurable policy thresholds** — `ai.sentinel.threshold-moderate`, `threshold-elevated`, `threshold-high`, and `threshold-critical` (defaults 0.2 / 0.4 / 0.6 / 0.8) are bound via `SentinelProperties` and `SentinelAutoConfiguration` into `ThresholdPolicyEngine`. Invalid configuration (not strictly increasing, out of `[0.0, 1.0]`, or non-finite) fails fast at startup with a clear `IllegalArgumentException`.
+- **X-Real-IP trust** — `X-Real-IP` is used only when the TCP peer is a trusted proxy and there is no forward-chain hint (no non-blank `X-Forwarded-For` or `Forwarded` header). If a hint is present but no client IP is parsed, resolution falls back to `getRemoteAddr()` instead of trusting `X-Real-IP`.
+- **Isolation Forest feature vector** — `RequestFeatures.toIsolationForestArray()` feeds five behavioral features into IF scoring and training; `toArray()` remains unchanged for the statistical scorer (still includes `headerFingerprintHash` and `ipBucket`).
 
 ---
 
@@ -99,10 +105,14 @@ Addressed items from the production review and audit:
 - **CompositeScorerTest:** `nanScoreReturnsOneNotBypass`, `negativeScoreReturnsOne`.
 - **CompositeEnforcementHandlerTest:** `throttleMapBoundedWhenOverMaxKeys`, `quarantineBoundedMapDoesNotThrow`, `getQuarantineCountReturnsActiveQuarantines`, `isQuarantinedExpiredEntryRemovedAtomically`.
 - **MonitorOnlyEnforcementHandlerTest:** `isQuarantinedDelegatesToDelegate`.
-- **SentinelFilterProxyTest:** trusted proxy + X-Forwarded-For / Forwarded / X-Real-IP behavior.
+- **SentinelFilterProxyTest:** trusted proxy + X-Forwarded-For / Forwarded / X-Real-IP behavior; untrusted `X-Real-IP`; placeholder XFF ignores `X-Real-IP`; fallback to `getRemoteAddr()`.
+- **ClientIpResolverTest:** forward-chain hint / `X-Real-IP` trust cases (mirrors resolver unit coverage).
+- **ThresholdPolicyEngineTest:** custom thresholds, validation errors for ordering and range.
+- **SentinelAutoConfigurationTest:** invalid threshold ordering fails context; custom thresholds bind to `PolicyEngine`.
+- **RequestFeaturesTest:** `toIsolationForestArray` five-feature shape.
+- **IsolationForestScorerTest:** fallback when no model, score in [0,1] after training, retrain failure does not break inference, atomic model swap, five-dimensional training buffer, IF ignores hash/ip bucket for inference, metadata.
 - **SentinelActuatorEndpointTest:** endpoint structure, `quarantineCount`, and when IF enabled the IF metadata keys.
 - **BoundedTrainingBufferTest:** boundedness, snapshot, concurrent adds, null/empty ignored.
-- **IsolationForestScorerTest:** fallback when no model, score in [0,1] after training, retrain failure does not break inference, atomic model swap, metadata.
 - **Demo:** `DemoIntegrationTest` (hello + actuator); test profile uses MONITOR and higher throttle for stability.
 
 ---
@@ -122,6 +132,10 @@ ai:
     internal-map-ttl: 5m
     warmup-min-samples: 2
     warmup-score: 0.4
+    threshold-moderate: 0.2
+    threshold-elevated: 0.4
+    threshold-high: 0.6
+    threshold-critical: 0.8
     throttle-requests-per-second: 5.0
     isolation-forest:
       enabled: false
@@ -144,7 +158,7 @@ From the audit, the following remain **not fixed** or **partially fixed** (see `
 
 - **Performance:** B1–B7 (e.g. MessageDigest per request, reflection per request, string concat hot path, telemetry streams, Counter.builder per emit, BaselineStore eviction stampede, multiple `currentTimeMillis`).
 - **Concurrency:** C2 (BaselineStore bucket count window), C3 (CompositeScorer ArrayList).
-- **Design / ops:** D1 (RequestContext unused), D2 (hash features in z-score), D4–D7 (policy thresholds not in properties, no Content-Type on error, filter order, no graceful degradation), D8 (actuator only has quarantineCount so far).
+- **Design / ops:** D1 (RequestContext unused), D2 (hash features in z-score), D4 partial (policy thresholds now configurable), D5–D7 (no Content-Type on error, filter order, no graceful degradation), D8 (actuator only has quarantineCount so far).
 - **Edge cases:** E1, E3–E7 (token age semantics, response committed, quarantine scope, BaselineStore TTL cliff, entropy gaming, parameterCount for JSON).
 
 These are documented in the audit with evidence and recommended follow-up.

--- a/ai-sentinel-core/src/main/java/io/aisentinel/core/model/RequestFeatures.java
+++ b/ai-sentinel-core/src/main/java/io/aisentinel/core/model/RequestFeatures.java
@@ -48,7 +48,7 @@ public final class RequestFeatures {
     public int ipBucket() { return ipBucket; }
 
     /**
-     * Returns features as a double array for ML scoring (statistical / isolation forest).
+     * Full feature vector for statistical scoring (Welford / z-score path).
      * Order: requestsPerWindow, endpointEntropy, tokenAgeSeconds, parameterCount, payloadSizeBytes, headerFingerprintHash, ipBucket
      */
     public double[] toArray() {
@@ -60,6 +60,20 @@ public final class RequestFeatures {
             payloadSizeBytes,
             headerFingerprintHash,
             ipBucket
+        };
+    }
+
+    /**
+     * Subset for Isolation Forest only: behavioral / magnitude features (no hash-derived ordinals).
+     * Order: requestsPerWindow, endpointEntropy, tokenAgeSeconds, parameterCount, payloadSizeBytes
+     */
+    public double[] toIsolationForestArray() {
+        return new double[] {
+            requestsPerWindow,
+            endpointEntropy,
+            tokenAgeSeconds,
+            parameterCount,
+            payloadSizeBytes
         };
     }
 

--- a/ai-sentinel-core/src/main/java/io/aisentinel/core/policy/ThresholdPolicyEngine.java
+++ b/ai-sentinel-core/src/main/java/io/aisentinel/core/policy/ThresholdPolicyEngine.java
@@ -17,11 +17,37 @@ public final class ThresholdPolicyEngine implements PolicyEngine {
         this(0.2, 0.4, 0.6, 0.8);
     }
 
+    /**
+     * @throws IllegalArgumentException if thresholds are NaN/infinite, out of [0,1], or not strictly ordered
+     */
     public ThresholdPolicyEngine(double moderate, double elevated, double high, double critical) {
+        validateThresholds(moderate, elevated, high, critical);
         this.thresholdModerate = moderate;
         this.thresholdElevated = elevated;
         this.thresholdHigh = high;
         this.thresholdCritical = critical;
+    }
+
+    /**
+     * Validates {@code moderate < elevated < high < critical} and each value in {@code [0, 1]}.
+     */
+    public static void validateThresholds(double moderate, double elevated, double high, double critical) {
+        double[] v = {moderate, elevated, high, critical};
+        for (int i = 0; i < v.length; i++) {
+            if (Double.isNaN(v[i]) || Double.isInfinite(v[i])) {
+                throw new IllegalArgumentException(
+                    "ai.sentinel policy thresholds must be finite numbers (NaN/infinity not allowed)");
+            }
+            if (v[i] < 0.0 || v[i] > 1.0) {
+                throw new IllegalArgumentException(
+                    "ai.sentinel policy thresholds must be within [0.0, 1.0]; got value at index " + i + "=" + v[i]);
+            }
+        }
+        if (!(moderate < elevated && elevated < high && high < critical)) {
+            throw new IllegalArgumentException(
+                "ai.sentinel policy thresholds must satisfy threshold-moderate < threshold-elevated < threshold-high < threshold-critical; got moderate="
+                    + moderate + ", elevated=" + elevated + ", high=" + high + ", critical=" + critical);
+        }
     }
 
     @Override

--- a/ai-sentinel-core/src/main/java/io/aisentinel/core/scoring/IsolationForestScorer.java
+++ b/ai-sentinel-core/src/main/java/io/aisentinel/core/scoring/IsolationForestScorer.java
@@ -62,7 +62,7 @@ public final class IsolationForestScorer implements AnomalyScorer {
             }
             return fb;
         }
-        double[] x = features.toArray();
+        double[] x = features.toIsolationForestArray();
         long t0 = System.nanoTime();
         double s = m.score(x);
         long infNanos = System.nanoTime() - t0;
@@ -96,7 +96,7 @@ public final class IsolationForestScorer implements AnomalyScorer {
             }
         }
         if (config.getSampleRate() >= 1.0 || ThreadLocalRandomHolder.nextDouble() < config.getSampleRate()) {
-            buffer.add(features.toArray());
+            buffer.add(features.toIsolationForestArray());
             acceptedTrainingSampleCount.incrementAndGet();
         }
     }

--- a/ai-sentinel-core/src/test/java/io/aisentinel/core/model/RequestFeaturesTest.java
+++ b/ai-sentinel-core/src/test/java/io/aisentinel/core/model/RequestFeaturesTest.java
@@ -31,4 +31,28 @@ class RequestFeaturesTest {
         assertThat(a[5]).isEqualTo(42);
         assertThat(a[6]).isEqualTo(123);
     }
+
+    @Test
+    void toIsolationForestArrayExcludesHashFeatures() {
+        var f = RequestFeatures.builder()
+            .identityHash("id")
+            .endpoint("/api")
+            .timestampMillis(0)
+            .requestsPerWindow(5)
+            .endpointEntropy(1.2)
+            .tokenAgeSeconds(60)
+            .parameterCount(3)
+            .payloadSizeBytes(100)
+            .headerFingerprintHash(42)
+            .ipBucket(123)
+            .build();
+
+        double[] ifVec = f.toIsolationForestArray();
+        assertThat(ifVec).hasSize(5);
+        assertThat(ifVec[0]).isEqualTo(5);
+        assertThat(ifVec[1]).isEqualTo(1.2);
+        assertThat(ifVec[2]).isEqualTo(60);
+        assertThat(ifVec[3]).isEqualTo(3);
+        assertThat(ifVec[4]).isEqualTo(100);
+    }
 }

--- a/ai-sentinel-core/src/test/java/io/aisentinel/core/policy/ThresholdPolicyEngineTest.java
+++ b/ai-sentinel-core/src/test/java/io/aisentinel/core/policy/ThresholdPolicyEngineTest.java
@@ -4,13 +4,12 @@ import io.aisentinel.core.model.RequestFeatures;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class ThresholdPolicyEngineTest {
 
-    @Test
-    void evaluateMapsScoreToAction() {
-        var engine = new ThresholdPolicyEngine();
-        var f = RequestFeatures.builder()
+    private static RequestFeatures dummyFeatures() {
+        return RequestFeatures.builder()
             .identityHash("id")
             .endpoint("/api")
             .timestampMillis(0)
@@ -22,11 +21,45 @@ class ThresholdPolicyEngineTest {
             .headerFingerprintHash(0)
             .ipBucket(0)
             .build();
+    }
+
+    @Test
+    void evaluateMapsScoreToAction() {
+        var engine = new ThresholdPolicyEngine();
+        var f = dummyFeatures();
 
         assertThat(engine.evaluate(0.1, f, "/api")).isEqualTo(EnforcementAction.ALLOW);
         assertThat(engine.evaluate(0.3, f, "/api")).isEqualTo(EnforcementAction.MONITOR);
         assertThat(engine.evaluate(0.5, f, "/api")).isEqualTo(EnforcementAction.THROTTLE);
         assertThat(engine.evaluate(0.7, f, "/api")).isEqualTo(EnforcementAction.BLOCK);
         assertThat(engine.evaluate(0.9, f, "/api")).isEqualTo(EnforcementAction.QUARANTINE);
+    }
+
+    @Test
+    void customThresholdsChangeBands() {
+        var engine = new ThresholdPolicyEngine(0.1, 0.3, 0.5, 0.7);
+        var f = dummyFeatures();
+        assertThat(engine.evaluate(0.05, f, "/api")).isEqualTo(EnforcementAction.ALLOW);
+        assertThat(engine.evaluate(0.1, f, "/api")).isEqualTo(EnforcementAction.MONITOR);
+        assertThat(engine.evaluate(0.35, f, "/api")).isEqualTo(EnforcementAction.THROTTLE);
+        assertThat(engine.evaluate(0.55, f, "/api")).isEqualTo(EnforcementAction.BLOCK);
+        assertThat(engine.evaluate(0.75, f, "/api")).isEqualTo(EnforcementAction.QUARANTINE);
+    }
+
+    @Test
+    void validateThresholdsRejectsNonAscendingOrder() {
+        assertThatThrownBy(() -> new ThresholdPolicyEngine(0.2, 0.2, 0.6, 0.8))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("threshold-moderate");
+    }
+
+    @Test
+    void validateThresholdsRejectsOutOfRange() {
+        assertThatThrownBy(() -> new ThresholdPolicyEngine(-0.1, 0.4, 0.6, 0.8))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("[0.0, 1.0]");
+        assertThatThrownBy(() -> new ThresholdPolicyEngine(0.1, 0.2, 0.3, 1.1))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("[0.0, 1.0]");
     }
 }

--- a/ai-sentinel-core/src/test/java/io/aisentinel/core/scoring/IsolationForestScorerTest.java
+++ b/ai-sentinel-core/src/test/java/io/aisentinel/core/scoring/IsolationForestScorerTest.java
@@ -7,20 +7,25 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class IsolationForestScorerTest {
 
-    private static RequestFeatures features(double... values) {
-        if (values.length < 7) throw new IllegalArgumentException("need 7 values");
+    /** IF scoring uses the five behavioral features only; hash/ipBucket vary for statistical path tests. */
+    private static RequestFeatures features(double rpw, double entropy, double tokenAge, int paramCount, long payload,
+                                            long headerHash, int ipBucket) {
         return RequestFeatures.builder()
             .identityHash("id")
             .endpoint("/api")
             .timestampMillis(0)
-            .requestsPerWindow(values[0])
-            .endpointEntropy(values[1])
-            .tokenAgeSeconds(values[2])
-            .parameterCount((int) values[3])
-            .payloadSizeBytes((long) values[4])
-            .headerFingerprintHash((long) values[5])
-            .ipBucket((int) values[6])
+            .requestsPerWindow(rpw)
+            .endpointEntropy(entropy)
+            .tokenAgeSeconds(tokenAge)
+            .parameterCount(paramCount)
+            .payloadSizeBytes(payload)
+            .headerFingerprintHash(headerHash)
+            .ipBucket(ipBucket)
             .build();
+    }
+
+    private static RequestFeatures features(double rpw, double entropy, double tokenAge, int paramCount, long payload) {
+        return features(rpw, entropy, tokenAge, paramCount, payload, 0L, 0);
     }
 
     @Test
@@ -29,7 +34,7 @@ class IsolationForestScorerTest {
         var config = new IsolationForestConfig(0.5, 50, 10, 5, 42L, 1.0);
         var scorer = new IsolationForestScorer(buffer, config);
         assertThat(scorer.isModelLoaded()).isFalse();
-        assertThat(scorer.score(features(1, 0, 60, 0, 100, 0, 0))).isEqualTo(0.5);
+        assertThat(scorer.score(features(1, 0, 60, 0, 100))).isEqualTo(0.5);
     }
 
     @Test
@@ -38,11 +43,11 @@ class IsolationForestScorerTest {
         var config = new IsolationForestConfig(0.5, 50, 20, 8, 42L, 1.0);
         var scorer = new IsolationForestScorer(buffer, config);
         for (int i = 0; i < 100; i++) {
-            buffer.add(new double[]{i % 10, 0.5, 60, 2, 100 + i, 0, 0});
+            buffer.add(new double[]{i % 10, 0.5, 60, 2, 100 + i});
         }
         scorer.retrain();
         assertThat(scorer.isModelLoaded()).isTrue();
-        double s = scorer.score(features(5, 0.5, 60, 2, 150, 0, 0));
+        double s = scorer.score(features(5, 0.5, 60, 2, 150));
         assertThat(s).isBetween(0.0, 1.0);
     }
 
@@ -51,12 +56,12 @@ class IsolationForestScorerTest {
         var buffer = new BoundedTrainingBuffer(10);
         var config = new IsolationForestConfig(0.4, 100, 5, 5, 42L, 1.0);
         var scorer = new IsolationForestScorer(buffer, config);
-        for (int i = 0; i < 5; i++) buffer.add(new double[]{1, 2, 3, 4, 5, 6, 7});
+        for (int i = 0; i < 5; i++) buffer.add(new double[]{1, 2, 3, 4, 5});
         scorer.retrain();
         assertThat(scorer.isModelLoaded()).isFalse();
-        assertThat(scorer.score(features(1, 2, 3, 4, 5, 6, 7))).isEqualTo(0.4);
+        assertThat(scorer.score(features(1, 2, 3, 4, 5))).isEqualTo(0.4);
         scorer.retrain();
-        assertThat(scorer.score(features(1, 2, 3, 4, 5, 6, 7))).isEqualTo(0.4);
+        assertThat(scorer.score(features(1, 2, 3, 4, 5))).isEqualTo(0.4);
     }
 
     @Test
@@ -65,18 +70,18 @@ class IsolationForestScorerTest {
         var config = new IsolationForestConfig(0.5, 30, 10, 6, 123L, 1.0);
         var scorer = new IsolationForestScorer(buffer, config);
         for (int i = 0; i < 50; i++) {
-            buffer.add(new double[]{i, i * 0.1, 60, 1, 100, 0, 0});
+            buffer.add(new double[]{i, i * 0.1, 60, 1, 100});
         }
         scorer.retrain();
         assertThat(scorer.isModelLoaded()).isTrue();
         long v1 = scorer.getModelVersion();
         for (int i = 0; i < 50; i++) {
-            buffer.add(new double[]{i + 50, 0.5, 60, 1, 200, 0, 0});
+            buffer.add(new double[]{i + 50, 0.5, 60, 1, 200});
         }
         scorer.retrain();
         long v2 = scorer.getModelVersion();
         assertThat(v2).isGreaterThanOrEqualTo(v1);
-        double score = scorer.score(features(25, 0.5, 60, 1, 150, 0, 0));
+        double score = scorer.score(features(25, 0.5, 60, 1, 150));
         assertThat(score).isBetween(0.0, 1.0);
     }
 
@@ -86,12 +91,12 @@ class IsolationForestScorerTest {
         var config = new IsolationForestConfig(0.5, 10, 20, 8, 42L, 1.0, 0.0);
         var scorer = new IsolationForestScorer(buffer, config);
         for (int i = 0; i < 100; i++) {
-            buffer.add(new double[]{i % 10, 0.5, 60, 2, 100 + i, 0, 0});
+            buffer.add(new double[]{i % 10, 0.5, 60, 2, 100 + i});
         }
         scorer.retrain();
         assertThat(scorer.isModelLoaded()).isTrue();
         long rejBefore = scorer.getRejectedTrainingSampleCount();
-        scorer.update(features(5, 0.5, 60, 2, 150, 0, 0));
+        scorer.update(features(5, 0.5, 60, 2, 150));
         assertThat(scorer.getRejectedTrainingSampleCount()).isGreaterThanOrEqualTo(rejBefore);
     }
 
@@ -101,12 +106,27 @@ class IsolationForestScorerTest {
         var config = new IsolationForestConfig(0.5, 10, 20, 8, 42L, 1.0, 1.0);
         var scorer = new IsolationForestScorer(buffer, config);
         for (int i = 0; i < 100; i++) {
-            buffer.add(new double[]{i % 10, 0.5, 60, 2, 100 + i, 0, 0});
+            buffer.add(new double[]{i % 10, 0.5, 60, 2, 100 + i});
         }
         scorer.retrain();
         long accBefore = scorer.getAcceptedTrainingSampleCount();
-        scorer.update(features(5, 0.5, 60, 2, 150, 0, 0));
+        scorer.update(features(5, 0.5, 60, 2, 150));
         assertThat(scorer.getAcceptedTrainingSampleCount()).isGreaterThan(accBefore);
+    }
+
+    @Test
+    void inferenceIgnoresHeaderHashAndIpBucket() {
+        var buffer = new BoundedTrainingBuffer(500);
+        var config = new IsolationForestConfig(0.5, 50, 20, 8, 42L, 1.0);
+        var scorer = new IsolationForestScorer(buffer, config);
+        for (int i = 0; i < 100; i++) {
+            buffer.add(new double[]{i % 10, 0.5, 60, 2, 100 + i});
+        }
+        scorer.retrain();
+        assertThat(scorer.isModelLoaded()).isTrue();
+        double a = scorer.score(features(5, 0.5, 60, 2, 150, 0L, 0));
+        double b = scorer.score(features(5, 0.5, 60, 2, 150, 99_999L, 7));
+        assertThat(a).isEqualTo(b);
     }
 
     @Test
@@ -118,7 +138,7 @@ class IsolationForestScorerTest {
         assertThat(scorer.getLastRetrainTimeMillis()).isEqualTo(0);
         assertThat(scorer.getModelAgeMillis()).isEqualTo(-1L);
         assertThat(scorer.getRetrainFailureCount()).isEqualTo(0L);
-        for (int i = 0; i < 15; i++) buffer.add(new double[]{1, 2, 3, 4, 5, 6, 7});
+        for (int i = 0; i < 15; i++) buffer.add(new double[]{1, 2, 3, 4, 5});
         assertThat(scorer.getBufferedSampleCount()).isEqualTo(15);
         scorer.retrain();
         assertThat(scorer.isModelLoaded()).isTrue();

--- a/ai-sentinel-spring-boot-starter/src/main/java/io/aisentinel/autoconfigure/config/SentinelAutoConfiguration.java
+++ b/ai-sentinel-spring-boot-starter/src/main/java/io/aisentinel/autoconfigure/config/SentinelAutoConfiguration.java
@@ -169,8 +169,13 @@ public class SentinelAutoConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
-    public PolicyEngine policyEngine() {
-        return new ThresholdPolicyEngine();
+    public PolicyEngine policyEngine(SentinelProperties props) {
+        return new ThresholdPolicyEngine(
+            props.getThresholdModerate(),
+            props.getThresholdElevated(),
+            props.getThresholdHigh(),
+            props.getThresholdCritical()
+        );
     }
 
     @Bean

--- a/ai-sentinel-spring-boot-starter/src/main/java/io/aisentinel/autoconfigure/config/SentinelProperties.java
+++ b/ai-sentinel-spring-boot-starter/src/main/java/io/aisentinel/autoconfigure/config/SentinelProperties.java
@@ -36,6 +36,15 @@ public class SentinelProperties {
     /** Score returned during warmup (cold-start) to avoid bypass. Default 0.4 (MONITOR). */
     private double warmupScore = 0.4;
 
+    /** Policy: scores at or above this map to MONITOR (below elevated). Default 0.2. */
+    private double thresholdModerate = 0.2;
+    /** Policy: scores at or above this map to THROTTLE. Default 0.4. */
+    private double thresholdElevated = 0.4;
+    /** Policy: scores at or above this map to BLOCK. Default 0.6. */
+    private double thresholdHigh = 0.6;
+    /** Policy: scores at or above this map to QUARANTINE. Default 0.8. */
+    private double thresholdCritical = 0.8;
+
     private IsolationForest isolationForest = new IsolationForest();
     private Telemetry telemetry = new Telemetry();
 

--- a/ai-sentinel-spring-boot-starter/src/main/java/io/aisentinel/autoconfigure/web/ClientIpResolver.java
+++ b/ai-sentinel-spring-boot-starter/src/main/java/io/aisentinel/autoconfigure/web/ClientIpResolver.java
@@ -10,7 +10,18 @@ import java.util.Locale;
 
 /**
  * Resolves the client IP from a request when the direct remote address is a trusted proxy.
- * Uses rightmost-untrusted selection for X-Forwarded-For and Forwarded (RFC 7239) headers.
+ * <p>
+ * When the TCP remote is trusted, resolution order is:
+ * <ol>
+ *   <li>{@code X-Forwarded-For} — rightmost-untrusted hop</li>
+ *   <li>{@code Forwarded} (RFC 7239) — same rightmost-untrusted logic on {@code for=}</li>
+ *   <li>{@code X-Real-IP} — only if there is <strong>no forward-chain hint</strong>: no non-blank
+ *       {@code X-Forwarded-For} and no non-blank {@code Forwarded} header. If either header is present
+ *       (even when parsing yields no client IP), {@code X-Real-IP} is ignored so an untrusted client
+ *       cannot pair a forged {@code X-Real-IP} with a dummy forward header while appearing as a trusted proxy.</li>
+ *   <li>Fallback: {@link HttpServletRequest#getRemoteAddr()}</li>
+ * </ol>
+ * If {@code trustedProxyEntries} is empty, or the remote is not trusted, headers are ignored and the remote address is returned.
  */
 public final class ClientIpResolver {
 
@@ -20,7 +31,7 @@ public final class ClientIpResolver {
     /**
      * If {@code trustedProxyEntries} is empty, returns {@link HttpServletRequest#getRemoteAddr()}.
      * If remote is not trusted, returns remote (headers ignored — spoof resistance).
-     * Otherwise parses X-Forwarded-For, then Forwarded, then X-Real-IP; falls back to remote.
+     * Otherwise parses X-Forwarded-For, then Forwarded; uses X-Real-IP only when no forward-chain hint exists.
      */
     public static String resolveClientIp(HttpServletRequest request, List<String> trustedProxyEntries) {
         String remote = request.getRemoteAddr();
@@ -41,11 +52,35 @@ public final class ClientIpResolver {
         if (fromForwarded != null) {
             return fromForwarded;
         }
+        if (hasForwardedChainHint(request)) {
+            return remote;
+        }
         String realIp = request.getHeader("X-Real-IP");
         if (realIp != null && !realIp.isBlank()) {
             return stripIpv6Brackets(realIp.trim());
         }
         return remote;
+    }
+
+    /**
+     * True when a non-blank {@code X-Forwarded-For} or {@code Forwarded} header is present.
+     */
+    static boolean hasForwardedChainHint(HttpServletRequest request) {
+        String xff = request.getHeader("X-Forwarded-For");
+        if (xff != null && !xff.isBlank()) {
+            return true;
+        }
+        Enumeration<String> forwardedMulti = request.getHeaders("Forwarded");
+        if (forwardedMulti != null) {
+            while (forwardedMulti.hasMoreElements()) {
+                String v = forwardedMulti.nextElement();
+                if (v != null && !v.isBlank()) {
+                    return true;
+                }
+            }
+        }
+        String forwardedSingle = request.getHeader("Forwarded");
+        return forwardedSingle != null && !forwardedSingle.isBlank();
     }
 
     static String resolveFromXForwardedFor(String xff, List<String> trustedProxyEntries) {

--- a/ai-sentinel-spring-boot-starter/src/test/java/io/aisentinel/autoconfigure/config/SentinelAutoConfigurationTest.java
+++ b/ai-sentinel-spring-boot-starter/src/test/java/io/aisentinel/autoconfigure/config/SentinelAutoConfigurationTest.java
@@ -1,10 +1,13 @@
 package io.aisentinel.autoconfigure.config;
 
+import io.aisentinel.autoconfigure.web.SentinelFilter;
+import io.aisentinel.core.model.RequestFeatures;
+import io.aisentinel.core.policy.EnforcementAction;
+import io.aisentinel.core.policy.PolicyEngine;
+import io.aisentinel.core.policy.ThresholdPolicyEngine;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.WebApplicationContextRunner;
-
-import io.aisentinel.autoconfigure.web.SentinelFilter;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -12,6 +15,21 @@ class SentinelAutoConfigurationTest {
 
     private final WebApplicationContextRunner contextRunner = new WebApplicationContextRunner()
         .withConfiguration(AutoConfigurations.of(SentinelAutoConfiguration.class));
+
+    private static RequestFeatures dummyFeatures() {
+        return RequestFeatures.builder()
+            .identityHash("id")
+            .endpoint("/api")
+            .timestampMillis(0)
+            .requestsPerWindow(1)
+            .endpointEntropy(0)
+            .tokenAgeSeconds(-1)
+            .parameterCount(0)
+            .payloadSizeBytes(0)
+            .headerFingerprintHash(0)
+            .ipBucket(0)
+            .build();
+    }
 
     @Test
     void autoConfigurationCreatesSentinelBeansWhenEnabled() {
@@ -26,5 +44,39 @@ class SentinelAutoConfigurationTest {
     @Test
     void propertiesAreAvailable() {
         contextRunner.run(context -> assertThat(context).hasSingleBean(SentinelProperties.class));
+    }
+
+    @Test
+    void invalidPolicyThresholdOrderingFailsStartup() {
+        contextRunner
+            .withPropertyValues(
+                "ai.sentinel.enabled=true",
+                "ai.sentinel.threshold-moderate=0.3",
+                "ai.sentinel.threshold-elevated=0.2",
+                "ai.sentinel.threshold-high=0.6",
+                "ai.sentinel.threshold-critical=0.8")
+            .run(ctx -> assertThat(ctx).hasFailed());
+    }
+
+    @Test
+    void customPolicyThresholdsBindAndDrivePolicyEngine() {
+        contextRunner
+            .withPropertyValues(
+                "ai.sentinel.enabled=true",
+                "ai.sentinel.threshold-moderate=0.1",
+                "ai.sentinel.threshold-elevated=0.3",
+                "ai.sentinel.threshold-high=0.5",
+                "ai.sentinel.threshold-critical=0.7")
+            .run(ctx -> {
+                assertThat(ctx).hasNotFailed();
+                PolicyEngine policy = ctx.getBean(PolicyEngine.class);
+                assertThat(policy).isInstanceOf(ThresholdPolicyEngine.class);
+                var f = dummyFeatures();
+                assertThat(policy.evaluate(0.05, f, "/api")).isEqualTo(EnforcementAction.ALLOW);
+                assertThat(policy.evaluate(0.15, f, "/api")).isEqualTo(EnforcementAction.MONITOR);
+                assertThat(policy.evaluate(0.35, f, "/api")).isEqualTo(EnforcementAction.THROTTLE);
+                assertThat(policy.evaluate(0.55, f, "/api")).isEqualTo(EnforcementAction.BLOCK);
+                assertThat(policy.evaluate(0.75, f, "/api")).isEqualTo(EnforcementAction.QUARANTINE);
+            });
     }
 }

--- a/ai-sentinel-spring-boot-starter/src/test/java/io/aisentinel/autoconfigure/web/ClientIpResolverTest.java
+++ b/ai-sentinel-spring-boot-starter/src/test/java/io/aisentinel/autoconfigure/web/ClientIpResolverTest.java
@@ -37,4 +37,82 @@ class ClientIpResolverTest {
 
         assertThat(ip).isEqualTo("192.168.1.1");
     }
+
+    @Test
+    void untrustedRemoteIgnoresForgedXRealIp() {
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getRemoteAddr()).thenReturn("198.51.100.2");
+        when(request.getHeader("X-Forwarded-For")).thenReturn(null);
+        when(request.getHeader("Forwarded")).thenReturn(null);
+        when(request.getHeader("X-Real-IP")).thenReturn("1.1.1.1");
+
+        String ip = ClientIpResolver.resolveClientIp(request, List.of("127.0.0.1"));
+
+        assertThat(ip).isEqualTo("198.51.100.2");
+    }
+
+    @Test
+    void trustedProxyUsesXRealIpOnlyWhenNoForwardChainHint() {
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getRemoteAddr()).thenReturn("127.0.0.1");
+        when(request.getHeader("X-Forwarded-For")).thenReturn(null);
+        when(request.getHeader("Forwarded")).thenReturn(null);
+        when(request.getHeader("X-Real-IP")).thenReturn("198.51.100.2");
+
+        String ip = ClientIpResolver.resolveClientIp(request, List.of("127.0.0.1"));
+
+        assertThat(ip).isEqualTo("198.51.100.2");
+    }
+
+    @Test
+    void trustedProxyWithPlaceholderXffIgnoresXRealIp() {
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getRemoteAddr()).thenReturn("127.0.0.1");
+        when(request.getHeader("X-Forwarded-For")).thenReturn(",,");
+        when(request.getHeader("Forwarded")).thenReturn(null);
+        when(request.getHeader("X-Real-IP")).thenReturn("9.9.9.9");
+
+        String ip = ClientIpResolver.resolveClientIp(request, List.of("127.0.0.1"));
+
+        assertThat(ip).isEqualTo("127.0.0.1");
+    }
+
+    @Test
+    void trustedProxyXffWinsOverXRealIp() {
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getRemoteAddr()).thenReturn("127.0.0.1");
+        when(request.getHeader("X-Forwarded-For")).thenReturn("203.0.113.10, 10.0.0.1");
+        when(request.getHeader("X-Real-IP")).thenReturn("9.9.9.9");
+
+        String ip = ClientIpResolver.resolveClientIp(request, List.of("127.0.0.1", "10.0.0.1"));
+
+        assertThat(ip).isEqualTo("203.0.113.10");
+    }
+
+    @Test
+    void noForwardedHeadersFallsBackToRemoteAddr() {
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getRemoteAddr()).thenReturn("10.0.0.50");
+        when(request.getHeader("X-Forwarded-For")).thenReturn(null);
+        when(request.getHeader("Forwarded")).thenReturn(null);
+        when(request.getHeader("X-Real-IP")).thenReturn(null);
+
+        String ip = ClientIpResolver.resolveClientIp(request, List.of("10.0.0.0/24"));
+
+        assertThat(ip).isEqualTo("10.0.0.50");
+    }
+
+    @Test
+    void hasForwardedChainHint_blankXffIsFalse() {
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getHeader("X-Forwarded-For")).thenReturn(" ");
+        assertThat(ClientIpResolver.hasForwardedChainHint(request)).isFalse();
+    }
+
+    @Test
+    void hasForwardedChainHint_nonBlankXffIsTrue() {
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getHeader("X-Forwarded-For")).thenReturn(",");
+        assertThat(ClientIpResolver.hasForwardedChainHint(request)).isTrue();
+    }
 }

--- a/ai-sentinel-spring-boot-starter/src/test/java/io/aisentinel/autoconfigure/web/SentinelFilterProxyTest.java
+++ b/ai-sentinel-spring-boot-starter/src/test/java/io/aisentinel/autoconfigure/web/SentinelFilterProxyTest.java
@@ -20,6 +20,7 @@ class SentinelFilterProxyTest {
         HttpServletRequest request = mock(HttpServletRequest.class);
         when(request.getRemoteAddr()).thenReturn("127.0.0.1");
         when(request.getHeader("X-Forwarded-For")).thenReturn("192.168.1.100, 10.0.0.1");
+        when(request.getHeader("X-Real-IP")).thenReturn("9.9.9.9");
 
         String ip = SentinelFilter.resolveClientIp(request, List.of("127.0.0.1", "10.0.0.1"));
 
@@ -93,5 +94,44 @@ class SentinelFilterProxyTest {
         String ip = SentinelFilter.resolveClientIp(request, List.of("127.0.0.1"));
 
         assertThat(ip).isEqualTo("198.51.100.2");
+    }
+
+    @Test
+    void untrustedClient_forgedXRealIpIgnored() {
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getRemoteAddr()).thenReturn("198.51.100.2");
+        when(request.getHeader("X-Forwarded-For")).thenReturn(null);
+        when(request.getHeader("Forwarded")).thenReturn(null);
+        when(request.getHeader("X-Real-IP")).thenReturn("1.1.1.1");
+
+        String ip = SentinelFilter.resolveClientIp(request, List.of("127.0.0.1"));
+
+        assertThat(ip).isEqualTo("198.51.100.2");
+    }
+
+    @Test
+    void trustedProxy_placeholderXffIgnoresForgedXRealIp() {
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getRemoteAddr()).thenReturn("127.0.0.1");
+        when(request.getHeader("X-Forwarded-For")).thenReturn(",,");
+        when(request.getHeader("Forwarded")).thenReturn(null);
+        when(request.getHeader("X-Real-IP")).thenReturn("9.9.9.9");
+
+        String ip = SentinelFilter.resolveClientIp(request, List.of("127.0.0.1"));
+
+        assertThat(ip).isEqualTo("127.0.0.1");
+    }
+
+    @Test
+    void trustedProxy_noForwardedHeaders_fallsBackToRemoteAddr() {
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getRemoteAddr()).thenReturn("10.0.0.50");
+        when(request.getHeader("X-Forwarded-For")).thenReturn(null);
+        when(request.getHeader("Forwarded")).thenReturn(null);
+        when(request.getHeader("X-Real-IP")).thenReturn(null);
+
+        String ip = SentinelFilter.resolveClientIp(request, List.of("10.0.0.0/24"));
+
+        assertThat(ip).isEqualTo("10.0.0.50");
     }
 }


### PR DESCRIPTION
This PR lands the three must-fix items called out before Stage 5, without changing the overall architecture.

Policy thresholds — ThresholdPolicyEngine no longer relies on fixed bands only. Operators can set ai.sentinel.threshold-moderate, threshold-elevated, threshold-high, and threshold-critical (defaults remain 0.2 / 0.4 / 0.6 / 0.8). Values are validated at startup: strictly increasing, in [0.0, 1.0], finite; invalid config fails fast with a clear error. SentinelProperties and SentinelAutoConfiguration wire the engine; tests cover binding, invalid ordering, and custom bands.

Client IP / X-Real-IP — ClientIpResolver still prefers X-Forwarded-For (rightmost-untrusted), then Forwarded, but X-Real-IP is only used when the peer is a trusted proxy and there is no forward-chain hint (no non-blank X-Forwarded-For or Forwarded). If a hint exists but no client IP is parsed, the resolver falls back to getRemoteAddr() instead of trusting X-Real-IP. Tests cover untrusted clients, trusted proxy + X-Real-IP, XFF + X-Real-IP, placeholder XFF, and remote fallback.

Isolation Forest — Full RequestFeatures and toArray() are unchanged for the statistical scorer. toIsolationForestArray() supplies five behavioral features only (no headerFingerprintHash / ipBucket). IsolationForestScorer uses it for scoring and the training buffer; tests assert five-dimensional samples and that hash/bucket do not affect IF scores.