### PR TITLE
Docs and hardening: branching workflow, contributor guides, and trainer/registry wiring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Design / local notes (do not commit)
 design_info.txt
-docs/
+docs/*
+!docs/configuration.md
 
 # Build (target/ and **/target/ = all Maven build outputs in every module)
 target/

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -25,6 +25,7 @@ Latency is optimized with bounded maps, careful locking, and lock-free IF infere
 ai-sentinel/
 ├── ai-sentinel-core/                 # Framework-agnostic engine
 ├── ai-sentinel-spring-boot-starter/  # Servlet filter, auto-config, actuator, Micrometer
+├── ai-sentinel-trainer/              # Optional app: Kafka consumer, IF training, filesystem registry publisher
 ├── ai-sentinel-demo/                 # Reference application
 └── scripts/                          # Optional Python traffic / training helpers
 ```
@@ -34,6 +35,22 @@ There is **no** `ai-sentinel-dashboard` module; visualize via Prometheus/Grafana
 ---
 
 ## 3. Request lifecycle
+
+**HTTP path (simplified):**
+
+```
+Client
+  ↓
+SentinelFilter
+  ↓
+Feature extraction → Scoring → Policy → Enforcement
+```
+
+**Optional training / registry path** (async and off-request for registry refresh; not on the servlet hot path for model fetch):
+
+```
+TrainingCandidatePublisher → Kafka (optional) → ai-sentinel-trainer → filesystem registry → ModelRefreshScheduler → IsolationForestScorer
+```
 
 ```mermaid
 flowchart LR
@@ -155,7 +172,27 @@ Trusted entries may be literal IPs or **CIDR** prefixes.
 
 ---
 
-## 10. Observability
+## 10. Distributed architecture
+
+Phase 5 adds **optional** coordination and training paths that do not change local scoring or policy math on the request hot path. Features are gated by `ai.sentinel.distributed.*`, `ai.sentinel.model-registry.*`, and trainer `aisentinel.trainer.*` properties.
+
+| Component | Role |
+|-----------|------|
+| **Cluster quarantine (read)** | `ClusterQuarantineReader` merges Redis into `isQuarantined` (OR with local), fail-open. |
+| **Cluster quarantine (write)** | After a real local `QUARANTINE`, async publish of `until` to Redis for peers. |
+| **Cluster throttle** | On **THROTTLE** only, optional **`ClusterThrottleStore`** (Redis fixed-window counter) before the local bucket; fail-open. |
+| **Training candidate publishing** | **`TrainingCandidatePublisher`** — async export after enforcement (log or Kafka). |
+| **Trainer** (`ai-sentinel-trainer`) | Optional Kafka consumer, bounded buffer, IF train, writes `{tenant}/active.json` + artifacts under a **filesystem** registry root. |
+| **Model registry** | **`ModelRegistryReader`** + **`FilesystemModelRegistry`** read pointers and payloads from that layout. |
+| **Model refresh** | **`ModelRefreshScheduler`** on serving nodes polls off-request and calls **`IsolationForestScorer.tryInstallFromRegistry`**. |
+
+**End-to-end flow (when enabled):** starter **nodes** → **publish** candidates (Phase 5.5) → **trainer** consumes and trains → **writes** registry artifacts → starter **nodes** **refresh** and install models (Phase 5.6). Redis and Kafka are optional; log transport and local-only operation remain valid.
+
+Local enforcement stays authoritative; Redis and transport failures are fail-open. Property names and validation scope: root [`README.md`](README.md).
+
+---
+
+## 11. Observability
 
 - **`DefaultTelemetryEmitter`** — JSON logs + Micrometer counters for events (verbosity and sampling configurable).
 - **`MicrometerSentinelMetrics`** — registers meters such as `aisentinel.score.composite`, `aisentinel.score.statistical`, `aisentinel.score.if`, `aisentinel.latency.pipeline`, `aisentinel.latency.scoring`, `aisentinel.latency.if`, per-action counters, retrain timers/counters, `aisentinel.failopen.count`, etc., with percentiles where applicable.
@@ -163,7 +200,7 @@ Trusted entries may be literal IPs or **CIDR** prefixes.
 
 ---
 
-## 11. Extension points (beans)
+## 12. Extension points (beans)
 
 | Override | Interface / type |
 |----------|------------------|
@@ -174,24 +211,31 @@ Trusted entries may be literal IPs or **CIDR** prefixes.
 | Telemetry | `TelemetryEmitter` |
 | Metrics | `SentinelMetrics` |
 | Training export | `TrainingCandidatePublisher` (default noop) |
+| Cluster throttle store | `ClusterThrottleStore` (default noop; Redis when wired) |
+| Model registry read | `ModelRegistryReader` (default **`FilesystemModelRegistry`** when Phase 5.6 auto-config applies) |
+
+**Wiring:** Spring Boot auto-configuration uses **`@ConditionalOnMissingBean`** on these types (see `SentinelAutoConfiguration`, `ModelRegistryAutoConfiguration`, and distributed packages). Provide your own bean of the same type to replace the default implementation.
 
 ---
 
-## 12. Dependencies (reality)
+## 13. Dependencies (reality)
 
 - **ai-sentinel-core:** SLF4J, Micrometer Core, Jakarta Servlet API (provided), Lombok (provided), JUnit/Mockito/AssertJ (test).
-- **ai-sentinel-spring-boot-starter:** Spring Boot Web, Actuator, Security (optional integration), Micrometer; depends on **ai-sentinel-core**.
+- **ai-sentinel-spring-boot-starter:** Spring Boot Web, Actuator, Security (optional integration), Micrometer; depends on **ai-sentinel-core** only (not on the trainer).
+- **ai-sentinel-trainer:** **ai-sentinel-core**, Spring Boot starter (`spring-boot-starter`), JSON (`spring-boot-starter-json`), Kafka (`spring-kafka`), Actuator, optional Micrometer Prometheus at runtime; Lombok (provided); test stack JUnit 5 / AssertJ / `spring-boot-starter-test`. Standalone deployable; **not** a transitive dependency of applications that only use the starter library.
 
 ---
 
-## 13. Testing strategy
+## 14. Testing strategy
 
-- **Unit tests** — scorers, policy boundaries, resolver logic, enforcement maps, IF buffer and retrain behavior.
-- **Spring slice tests** — auto-configuration, actuator JSON shape, filter/proxy integration.
+- **Unit tests** — `ai-sentinel-core`: scorers, policy boundaries, resolver logic, enforcement maps, IF buffer and retrain behavior, codec/metadata.
+- **Spring slice tests** — `ai-sentinel-spring-boot-starter`: auto-configuration, actuator JSON shape, filter/proxy integration, model registry beans (`io.aisentinel.autoconfigure.model.*`).
+- **Distributed / Redis** — `io.aisentinel.validation.*` and related tests: Testcontainers Redis (`@Testcontainers(disabledWithoutDocker = true)`). **Docker** (or a Docker-compatible CI agent) is required to run those tests; they are skipped when Docker is unavailable.
+- **Trainer** — `ai-sentinel-trainer` unit tests (orchestrator, buffer, message parser).
 - **Demo** — `DemoIntegrationTest` smoke test with embedded server.
 
 ---
 
-## 14. Historical / roadmap note
+## 15. Design evolution
 
-Earlier planning documents referred to Smile-based Isolation Forest, strict per-stage timeouts, and a dashboard module. **Those are not the current implementation.** For Phase 5 distributed behavior and Redis integration, see the root [`README.md`](README.md). Optional extended notes may exist only under a local **`docs/`** tree (gitignored). **Stage 5** adds optional **cluster quarantine read** (Redis-backed `isQuarantined` OR-merge, fail-open) and optional **cluster quarantine write** (after a real local `QUARANTINE` in `ENFORCE` mode, publish `untilEpochMillis` to Redis with a matching key layout and TTL; async and fail-open so local enforcement stays authoritative). **Phase 5.4** adds optional **cluster throttle**: on the **THROTTLE** action only, a Redis fixed-window counter per enforcement key runs **before** the local throttle bucket (fail-open if Redis fails). A per-JVM **in-flight semaphore** caps concurrent throttle Redis evals; saturation is fail-open with a dedicated executor-rejected metric, separate from Redis timeout/failure counters. **Phase 5.5** adds optional **training candidate publishing** after enforcement: bounded async export (logging or optional Kafka), **schema v2** events with **`eventId`** and **SHA-256 fingerprints** (no raw endpoint or enforcement-key strings in JSON), feature snapshots copied on the request thread, stratified sampling option, clamped Kafka send timeout on workers, fail-open, no request-path blocking. Scoring, policy, and local enforcement semantics remain unchanged. **Phase 5.6** adds the **`ai-sentinel-trainer`** module (optional Kafka consumer, bounded buffer, IF train, **filesystem** registry writer) and starter-side **`FilesystemModelRegistry` + `ModelRefreshScheduler`** so nodes **poll** for new `active.json` and **atomically install** decoded models via **`IsolationForestScorer.tryInstallFromRegistry`** (fail-open, last-known-good, no request-path fetch). **Phase 5.3** (verification) adds integration-style tests under `ai-sentinel-spring-boot-starter` (`io.aisentinel.validation.*` and related quarantine tests), including a **single-JVM** MockMvc + `SentinelFilter` check that cluster quarantine drives HTTP blocking; see the root README **Phase 5.3 — Distributed validation** for scope (no automated two-JVM suite yet). **Not** in scope yet: Redis/S3 model registry backends, central online inference, Phase 6 ML optimization / research benchmarking.
+The codebase grew from a **single-node** library (**Phases 0–4**: core engine, Spring integration, Isolation Forest, hardening) to **optional distributed** behavior in **Phase 5**: Redis-backed cluster quarantine and throttle, training candidate export, the **`ai-sentinel-trainer`** service, and filesystem model registry with node-side refresh (**Phase 5.6**). Older planning assumed external ML stacks and a dashboard module; the **current** tree uses an in-core Isolation Forest and Micrometer instead. **Phase 5.3** adds automated validation (single-JVM Testcontainers today). **Phase 6** may add tuning, alternative models, and operational tooling (see README roadmap). **Not** in the current codebase: central online inference; Redis/S3-backed artifact registries as first-class products.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,164 @@
+# Contributing to AI-Sentinel
+
+Thanks for helping improve AI-Sentinel. Contributions should match the project’s engineering style: small, reviewable changes; tests when behavior changes; documentation updates when user-visible behavior or configuration changes.
+
+---
+
+## Project structure
+
+| Module | Purpose |
+|--------|---------|
+| **ai-sentinel-core** | Framework-agnostic engine: features, scorers, policy, enforcement, pipeline contracts, Isolation Forest training/scoring, model artifact types (`io.aisentinel.model.*`). |
+| **ai-sentinel-spring-boot-starter** | Spring Boot auto-configuration, servlet filter, `SentinelProperties`, actuator, Micrometer adapter, optional distributed and model-registry beans. |
+| **ai-sentinel-trainer** | Optional standalone Spring Boot app: consumes training candidates (Kafka when enabled), trains IF, publishes to a filesystem model registry. See [`ai-sentinel-trainer/README.md`](ai-sentinel-trainer/README.md). |
+| **ai-sentinel-demo** | Reference app for local runs and smoke tests. |
+
+---
+
+## Where to start
+
+When reading the codebase:
+
+1. **`SentinelPipeline`** ([`ai-sentinel-core`](ai-sentinel-core/src/main/java/io/aisentinel/core/SentinelPipeline.java)) — orchestrates extract → score → policy → enforce → telemetry and optional training publish.
+2. **`SentinelFilter`** ([`ai-sentinel-spring-boot-starter`](ai-sentinel-spring-boot-starter/src/main/java/io/aisentinel/autoconfigure/web/SentinelFilter.java)) — servlet entry point that invokes the pipeline once per request.
+3. **`SentinelAutoConfiguration`** ([`ai-sentinel-spring-boot-starter`](ai-sentinel-spring-boot-starter/src/main/java/io/aisentinel/autoconfigure/config/SentinelAutoConfiguration.java)) — registers beans and `@ConditionalOnMissingBean` extension points.
+
+Then see [`ARCHITECTURE.md`](ARCHITECTURE.md) for the full picture.
+
+---
+
+## Branching strategy
+
+| Branch | Purpose |
+|--------|---------|
+| **`main`** | Stable, release-quality code. Tagged for releases. Not a direct PR target for normal work. |
+| **`dev`** | Active integration branch. Default target for all pull requests. |
+
+### For contributors
+
+1. Branch from **`dev`**
+2. Open your PR against **`dev`**
+3. Use descriptive branch names:
+
+| Prefix | Use |
+|--------|-----|
+| `feature/` | New functionality |
+| `bugfix/` | Bug fixes (reference issue number if applicable) |
+| `docs/` | Documentation changes |
+| `chore/` | Build, CI, dependency updates |
+| `hotfix/` | Urgent fix targeting `main` (maintainer-approved only) |
+
+### Hotfixes (rare)
+
+If a maintainer designates an issue as:
+
+- hotfix
+- security
+- release-blocker
+
+Then:
+
+- branch from `main`
+- PR into `main`
+- maintainer merges `main` back into `dev`
+
+### Releases
+
+Maintainers:
+
+- merge `dev` → `main`
+- tag release (e.g. `v0.2.0`)
+
+Contributors do NOT manage releases.
+
+---
+
+## Prerequisites
+
+- **Java 21** (see root `pom.xml`)
+- **Maven 3.8+**
+- **Docker** — optional; required only to run Testcontainers-based tests in `ai-sentinel-spring-boot-starter` (skipped when Docker is unavailable)
+
+---
+
+## Build
+
+From the repository root:
+
+```bash
+mvn clean install
+```
+
+---
+
+## Tests
+
+```bash
+mvn test
+```
+
+Run tests before opening a PR. Distributed Redis tests need Docker when enabled.
+
+---
+
+## Run the demo
+
+```bash
+mvn -pl ai-sentinel-demo spring-boot:run
+```
+
+Optional IF-focused profile:
+
+```bash
+mvn -pl ai-sentinel-demo spring-boot:run -Dspring-boot.run.profiles=stage2
+```
+
+---
+
+## Code style
+
+- Follow existing naming and package layout (`io.aisentinel.*`).
+- Prefer focused changes; avoid unrelated refactors in the same PR.
+- Match formatting and patterns used in nearby code.
+- Keep public API changes minimal and backward compatible unless explicitly agreed.
+
+---
+
+## Commits
+
+- Use clear, imperative subject lines (e.g. `fix: clarify cluster throttle timeout in README`).
+- Avoid noisy or unrelated commits; squash locally if needed before push.
+
+---
+
+## Pull requests
+
+- Target the **`dev`** branch unless your change is a maintainer-approved hotfix (see **Branching strategy** above).
+- Describe **what** changed and **why** (short summary is enough).
+- Link related issues if any.
+- Ensure `mvn test` passes.
+- Update **README**, **ARCHITECTURE**, **`docs/configuration.md`**, and module READMEs when behavior or configuration changes.
+
+---
+
+## Where to plug in new behavior
+
+| Area | Extension | Notes |
+|------|-----------|--------|
+| **Scoring** | `FeatureExtractor`, `AnomalyScorer` / `CompositeScorer`, `IsolationForestScorer` | Hot path must stay bounded and non-blocking for scoring. |
+| **Distributed** | `ClusterQuarantineReader` / `Writer`, `ClusterThrottleStore`, `TrainingCandidatePublisher` | Optional; fail-open; see [`ARCHITECTURE.md`](ARCHITECTURE.md) §10. |
+| **Trainer** | Separate module; consumes Kafka when `aisentinel.trainer.kafka.enabled=true` | Publishes to filesystem layout consumed by `ModelRegistryReader` on nodes. |
+| **Registry on nodes** | `ModelRegistryReader` (default: `FilesystemModelRegistry` when auto-config applies) | Refresh is off-request; no registry I/O on the servlet thread. |
+
+Use `@ConditionalOnMissingBean` where the starter already defines a bean so applications can override.
+
+---
+
+## Invariants (do not break)
+
+1. **Request path** — Scoring and enforcement must not perform unbounded blocking or network I/O that can stall the filter thread beyond documented timeouts (e.g. Redis lookups for cluster features).
+2. **Fail-open** — When optional distributed or training features fail, the request should still be handled per policy where the code documents fail-open behavior.
+3. **Bounded memory** — Training buffers, caches, and async queues must remain capped; no unbounded growth on the hot path.
+4. **Local enforcement authority** — Cluster quarantine/throttle views are additive; local maps and decisions remain the baseline unless documented otherwise.
+
+Details: [`ARCHITECTURE.md`](ARCHITECTURE.md).

--- a/README.md
+++ b/README.md
@@ -1,70 +1,48 @@
 # AI-Sentinel
 
-**AI-assisted behavioral anomaly detection and policy-driven enforcement for Spring Boot APIs.**
+**Behavioral anomaly detection and policy enforcement for Spring Boot APIs.**
 
-AI-Sentinel scores each request using privacy-oriented features (rates, entropy, payload size, and similar signals), combines statistical baselines with an optional in-process **Isolation Forest** model, and maps scores to actions: allow, monitor, throttle, block, or quarantine. It is designed as a **library and starter**, not a hosted service: everything runs in your JVM with clear extension points.
+**What it is:** A library and starter that scores each request from privacy-oriented features (rates, entropy, payload size, and related signals), combines a statistical baseline with an optional **Isolation Forest** model, and maps the result to actions: allow, monitor, throttle, block, or quarantine.
 
----
+**Problem it addresses:** Static rules and coarse rate limits miss gradual or identity-specific abuse. AI-Sentinel adds **per-identity** behavior signals as a complement to authentication and infrastructure controls.
 
-## Why this exists
-
-Traditional WAFs and static rules miss gradual abuse and novel patterns. This project explores **unsupervised, per-identity behavior** as a complement to auth and rate limits—useful for portfolios, experiments, and as a foundation for stricter production hardening later.
+**How it runs:** Everything executes **in-process** in your JVM—no hosted scoring service. A servlet **filter** drives the pipeline (extract → score → policy → enforce). Optional **Phase 5** pieces add Redis-backed cluster views, async training export, a separate **trainer** app, and filesystem **model registry** refresh on serving nodes.
 
 ---
 
-## Core capabilities
+## Quickstart
+
+**Prerequisites:** Java 21, Maven 3.8+ (Python optional for `scripts/`).
+
+**End-to-end training path** (optional Phase 5.5 → 5.6):
+
+```
+Client
+  ↓
+SentinelFilter
+  ↓
+Scoring → Policy → Enforcement
+  ↓
+  └─ optional: TrainingPublisher → Kafka → Trainer → model registry → Node refresh (IF)
+```
+
+**Steps**
+
+1. **Build** — `git clone <repository-url> && cd ai-sentinel && mvn clean install`
+2. **Demo API** — `mvn -pl ai-sentinel-demo spring-boot:run` → `http://localhost:8080/api/hello` and `http://localhost:8080/actuator/sentinel`
+3. **Optional trainer** — With Kafka and candidates flowing: `mvn -pl ai-sentinel-trainer spring-boot:run`, set `aisentinel.trainer.kafka.enabled=true`, and align registry paths with `ai.sentinel.model-registry.filesystem-root`. See [`ai-sentinel-trainer/README.md`](ai-sentinel-trainer/README.md).
+4. **Tests** — `mvn test` (Docker optional for some starter integration tests)
+
+---
+
+## Key features
 
 - **Feature extraction** — Rolling counts, endpoint entropy, token age, parameter count, payload size, header fingerprint hash, IP bucket (no raw body or token storage in features).
-- **Scoring** — Welford-based statistical scorer (always on) plus optional **Isolation Forest** (bounded training buffer, async retrain, fallback when no model).
-- **Policy** — `ThresholdPolicyEngine` with **configurable** score bands (`threshold-moderate` … `threshold-critical`).
+- **Scoring** — Welford statistical scorer (always on) plus optional **Isolation Forest** (bounded training buffer, async retrain, fallback when no model).
+- **Policy** — `ThresholdPolicyEngine` with configurable score bands (`threshold-moderate` … `threshold-critical`).
 - **Enforcement** — Throttle, HTTP block, time-bound quarantine; **MONITOR** mode logs without blocking.
-- **Operations** — **Startup grace** (monitor-only window), **enforcement scope** (identity vs identity+endpoint), **trusted proxy** parsing (X-Forwarded-For, Forwarded, guarded X-Real-IP).
-- **Observability** — JSON telemetry, Micrometer meters (`aisentinel.*`), custom **`/actuator/sentinel`** endpoint.
-
----
-
-## Current maturity
-
-Stages **0–4** are implemented in this repository (core engine, Spring Boot integration, Isolation Forest, security/ops hardening, Micrometer/actuator depth). **Pre–Stage 5** fixes (configurable thresholds, safer X-Real-IP, IF-only feature vector) are included. **Stage 5** is **partially** started: **shared quarantine** can use **Redis** for a **read path** (merge cluster view into `isQuarantined`, fail-open) and an optional **write path** (propagate local `QUARANTINE` to Redis for peer nodes, fail-open, non-blocking). **Phase 5.4** adds optional **cluster throttle** for the THROTTLE band only (fixed-window Redis counter per enforcement key, fail-open). Kafka, trainer, model registry, training pipeline, and broader distributed ML lifecycle items are **not** implemented yet. Extended Phase 5 scope and failure-mode notes may be kept locally at **`docs/PHASE5_DISTRIBUTED_DESIGN.md`** (the `docs/` tree is gitignored and is not part of the published repository).
-
-Architecture and data flow: [`ARCHITECTURE.md`](ARCHITECTURE.md).
-
----
-
-## Requirements
-
-- **Java 21** (see root `pom.xml`)
-- **Maven 3.8+**
-- **Python 3.7+** (optional; for `scripts/` only)
-
----
-
-## Quick start
-
-```bash
-git clone <repository-url>
-cd ai-sentinel
-mvn clean install -q
-```
-
-### Run the demo
-
-```bash
-mvn -pl ai-sentinel-demo spring-boot:run
-```
-
-Then:
-
-```bash
-curl -s http://localhost:8080/api/hello
-curl -s http://localhost:8080/actuator/sentinel | jq .
-```
-
-### Run tests
-
-```bash
-mvn test
-```
+- **Operations** — Startup grace (monitor-only window), enforcement scope (identity vs identity+endpoint), trusted proxy parsing (X-Forwarded-For, Forwarded, guarded X-Real-IP).
+- **Observability** — JSON telemetry, Micrometer (`aisentinel.*`), **`/actuator/sentinel`**.
 
 ---
 
@@ -73,10 +51,11 @@ mvn test
 | Module | Role |
 |--------|------|
 | **ai-sentinel-core** | Features, statistical + IF scoring, policy, enforcement, pipeline, telemetry contracts |
-| **ai-sentinel-spring-boot-starter** | Auto-configuration, servlet filter, `SentinelProperties`, actuator endpoint, Micrometer adapter |
-| **ai-sentinel-demo** | Sample app (`/api/hello`, etc.), actuator exposure, optional traffic simulator hookup |
+| **ai-sentinel-spring-boot-starter** | Auto-configuration, servlet filter, `SentinelProperties`, actuator, Micrometer adapter |
+| **ai-sentinel-trainer** | Optional app: Kafka consumer for training candidates, IF training, filesystem model registry publisher |
+| **ai-sentinel-demo** | Reference app (`/api/hello`), actuator, optional traffic simulator |
 
-There is **no** `ai-sentinel-dashboard` module in this repo; use Prometheus/Grafana or logs against `aisentinel.*` metrics if you need charts.
+There is no `ai-sentinel-dashboard` module; use Prometheus/Grafana or logs for charts.
 
 ---
 
@@ -101,67 +80,26 @@ ai:
 
 ---
 
-## Key configuration
+## Architecture
 
-| Property | Default | Notes |
-|----------|---------|--------|
-| `ai.sentinel.enabled` | `true` | Master switch |
-| `ai.sentinel.mode` | `ENFORCE` | `OFF`, `MONITOR`, `ENFORCE` |
-| `ai.sentinel.exclude-paths` | actuator, health, static, favicon | Comma-separated Ant-style patterns |
-| `ai.sentinel.trusted-proxies` | _(empty)_ | IPs or CIDRs; when remote matches, client IP from forwarded headers (see architecture doc) |
-| `ai.sentinel.threshold-moderate` … `threshold-critical` | `0.2` … `0.8` | Strictly increasing, in `[0,1]` |
-| `ai.sentinel.warmup-min-samples` / `warmup-score` | `2` / `0.4` | Cold-start statistical behavior |
-| `ai.sentinel.startup-grace-period` | `0` | Duration (e.g. `5m`) enforcing monitor-only after startup |
-| `ai.sentinel.enforcement-scope` | `IDENTITY_ENDPOINT` | Throttle/quarantine key scope |
-| `ai.sentinel.isolation-forest.enabled` | `false` | Real in-core IF (not a stub) |
-| `ai.sentinel.telemetry.log-verbosity` | `ANOMALY_ONLY` | `FULL`, `ANOMALY_ONLY`, `SAMPLED`, `NONE` |
-| `ai.sentinel.distributed.cluster-quarantine-read-enabled` | `false` | Merge cluster quarantine into `isQuarantined` (local OR Redis view) |
-| `ai.sentinel.distributed.cluster-quarantine-write-enabled` | `false` | After local `QUARANTINE`, publish `until` to Redis (requires `distributed.enabled`, `redis.enabled`, template; async, fail-open) |
-| `ai.sentinel.distributed.cluster-throttle-enabled` | `false` | On the **THROTTLE** action path only, consult a Redis fixed-window counter per enforcement key (cluster-wide cap; fail-open if Redis fails; requires `distributed.enabled`, `redis.enabled`, template) |
-| `ai.sentinel.distributed.cluster-throttle-window` | `1s` | Wall-clock window length for the cluster throttle counter (validated ≥ 100ms) |
-| `ai.sentinel.distributed.cluster-throttle-max-requests-per-window` | `30` | Max requests cluster-wide per enforcement key per window when cluster throttle is enabled (validated ≥ 1) |
-| `ai.sentinel.distributed.cluster-throttle-max-in-flight` | `1024` | Per-JVM semaphore cap for concurrent cluster-throttle Redis evals; extra evaluations fail-open (metric `aisentinel.distributed.throttle.executor.rejected`); runtime clamp `[1, 50000]` |
-| `ai.sentinel.distributed.cluster-throttle-timeout` | _(unset)_ | Max wait on the throttle Redis future; when unset or non-positive, uses `distributed.redis.lookup-timeout` |
-| `ai.sentinel.distributed.training-publish-enabled` | `false` | Phase 5.5: async export of versioned training candidates after enforcement (fail-open; bounded) |
-| `ai.sentinel.distributed.training-publish-sample-rate` | `0.1` | Uniform fraction for the probabilistic sample gate (0–1); high composite scores can bypass when stratified sampling is on |
-| `ai.sentinel.distributed.training-publish-stratified-sampling` | `true` | When true, composite ≥ `training-publish-high-composite-bypass-sample-min-score` skips the uniform sample draw |
-| `ai.sentinel.distributed.training-publish-high-composite-bypass-sample-min-score` | `0.4` | Inclusive floor for bypassing uniform sampling when stratified sampling is enabled (0–1) |
-| `ai.sentinel.distributed.training-publish-max-in-flight` | `256` | Semaphore cap for concurrent publish tasks; excess dropped with metric |
-| `ai.sentinel.distributed.training-publish-timeout` | `2s` | Max wait on Kafka send completion (`future.get`); validated ≤ 30s; transport clamps to 10s |
-| `ai.sentinel.distributed.training-publish-min-composite-score` | `0` | Minimum composite score to export (inclusive) |
-| `ai.sentinel.distributed.training-publish-apply-if-anti-poisoning` | `true` | Skip export when IF score &gt; `isolation-forest.training-rejection-score-threshold` (when IF score present) |
-| `ai.sentinel.distributed.training-publisher-node-id` | _(empty)_ | Optional instance id in exported events (max length 128) |
-| `ai.sentinel.distributed.training-kafka-enabled` | `false` | Use `KafkaTemplate` when present (requires `spring-kafka` + broker config); else JSON log line transport |
-| `ai.sentinel.distributed.training-candidates-topic` | `aisentinel.training.candidates` | Kafka topic when Kafka transport is active |
-| `ai.sentinel.distributed.enabled` | `false` | Phase 5 master switch for Redis-backed distributed features |
-| `ai.sentinel.distributed.redis.enabled` | `false` | Enables Redis-backed beans when `spring-boot-starter-data-redis` and a `StringRedisTemplate` are present |
-| `ai.sentinel.distributed.redis.key-prefix` | `aisentinel` | Key prefix for quarantine keys `{prefix}:{tenant}:q:{enforcementKey}` and throttle keys `{prefix}:{tenant}:th:{bucket}:{enforcementKey}` |
-| `ai.sentinel.distributed.redis.lookup-timeout` | `50ms` | Max wait on async Redis futures for **cluster quarantine GET** and (when `cluster-throttle-timeout` is unset) **cluster throttle** Lua eval; prefer **Lettuce** as the Redis client and align `spring.data.redis.timeout` with these budgets |
-| `ai.sentinel.distributed.redis.max-in-flight-quarantine-writes` | `256` | Semaphore cap for concurrent async cluster quarantine SETs; extra publishes are dropped (metric) without blocking the caller |
-| `ai.sentinel.distributed.cache.enabled` | `true` | When `false`, skip the local cache (every lookup hits Redis within `lookup-timeout`) |
-| `ai.sentinel.distributed.cache.ttl` / `cache.max-entries` | `2s` / `10000` | Local bounded cache for Redis quarantine lookups |
-| `ai.sentinel.distributed.cache.negative-ttl` | _(unset)_ | TTL for negative (miss) cache lines; if unset, derived as `max(100ms, min(positiveTtl/2, 2s))` |
-| `ai.sentinel.model-registry.refresh-enabled` | `false` | Phase 5.6: background poll filesystem registry for newer IF artifacts (requires IF enabled + non-blank `filesystem-root`) |
-| `ai.sentinel.model-registry.filesystem-root` | _(empty)_ | Registry root shared with `ai-sentinel-trainer` output (`{root}/{tenant}/active.json` + `artifacts/`) |
-| `ai.sentinel.model-registry.poll-interval` | `5m` | Poll interval (validated 10s–24h) |
+Runtime design, extension points (`@ConditionalOnMissingBean`), and the distributed pipeline are described in **[`ARCHITECTURE.md`](ARCHITECTURE.md)** (request path §3, distributed §10, testing §14).
 
-Add `spring-boot-starter-data-redis` and Redis connection settings (`spring.data.redis.*`) when using cluster quarantine read/write and/or cluster throttle. Quarantine write propagation runs **asynchronously** after local quarantine is applied; Redis failures do not roll back local quarantine. Cluster throttle uses a short-budget async Redis **INCR** + **EXPIRE** script; on timeout or error the check **allows** the request (fail-open) and local per-node throttling still applies afterward. The **filter thread** waits up to the configured throttle/quarantine timeout for the Redis future, so **Redis round-trip latency is part of the request-path budget** for that check (async handoff only; no unbounded blocking beyond the timeout).
+Phases **0–5.6** are implemented (core through optional Redis, training export, **`ai-sentinel-trainer`**, filesystem registry refresh). The main **gap** for multi-node testing is **automated multi-JVM** validation (integration tests today use one JVM per suite).
 
-### Enable Isolation Forest locally (demo)
+---
 
-Use the bundled **stage2** profile (tuned for faster training):
+## Configuration
 
-```bash
-mvn -pl ai-sentinel-demo spring-boot:run -Dspring-boot.run.profiles=stage2
-```
+- **Prefix:** `ai.sentinel.*` (starter), `aisentinel.trainer.*` (trainer module).
+- **High level:** `enabled` / `mode`, thresholds, `isolation-forest.*`, `distributed.*` (cluster quarantine, throttle, training publish), `model-registry.*`.
 
-Config source: `ai-sentinel-demo/src/main/resources/application-stage2.yaml`.
+**Full property table, Redis notes, and IF demo profile:** **[`docs/configuration.md`](docs/configuration.md)**.
 
 ---
 
 ## Actuator and metrics
 
-Expose the custom endpoint (already set in the demo):
+Expose the custom endpoint (as in the demo):
 
 ```yaml
 management:
@@ -171,128 +109,56 @@ management:
         include: health,info,prometheus,sentinel
 ```
 
-**`GET /actuator/sentinel`** returns JSON including, among others:
+**`GET /actuator/sentinel`** — config flags, quarantine/throttle counts, IF state, `lastScoreComponents`, distributed/throttle summaries when enabled.
 
-- `enabled`, `mode`, `isolationForestEnabled`, `startupGraceActive`, `enforcementScope`
-- `quarantineCount`, `activeThrottleCount`
-- `lastScoreComponents` — snapshot from the **last** scored request: `statistical`, optional `isolationForest`, `composite`, `evaluatedAtMillis` (empty `{}` until traffic hits the filter)
-- When IF is enabled: `isolationForestModelLoaded`, `isolationForestBufferedSampleCount`, `isolationForestModelVersion`, retrain timestamps, `acceptedTrainingSampleCount`, `rejectedTrainingSampleCount`
-- When Micrometer is present: `scoreSummary`, `latencySummary`, `modelRetrainSuccessCount`, `modelRetrainFailureCount`, `distributedMetrics`, `distributedThrottleMetrics`
-- Distributed: `distributedClusterThrottleEnabled`, `clusterThrottleStoreType`, `distributedThrottle` (degraded / last Redis error), throttle window and max-per-window echo fields
-
-**Prometheus** (`/actuator/prometheus`) includes meters prefixed with **`aisentinel.`** (e.g. `aisentinel_score_composite`, `aisentinel_latency_pipeline_seconds`, `aisentinel_action_allow_total`). Example:
-
-```bash
-curl -s http://localhost:8080/actuator/prometheus | grep aisentinel
-```
+**Prometheus** — meters prefixed with `aisentinel.` (e.g. `curl -s http://localhost:8080/actuator/prometheus | grep aisentinel`).
 
 ---
 
 ## Scripts
 
-Python utilities (stdlib only); see **[`scripts/README.md`](scripts/README.md)**.
-
-| Script | Purpose |
-|--------|---------|
-| `scripts/train_monitor.py` | Send traffic and poll `/actuator/sentinel` until an IF model is loaded |
-| `scripts/traffic_simulator.py` | Sustained **normal**, **burst**, or **attack**-style traffic for local experiments |
-
-Typical flow: start the demo with **`stage2`** profile, then `python scripts/train_monitor.py`.
+Python (stdlib only): **[`scripts/README.md`](scripts/README.md)** (`train_monitor.py`, `traffic_simulator.py`). Typical: run the demo with the **`stage2`** profile, then `python scripts/train_monitor.py`.
 
 ---
 
 ## Roadmap (high level)
 
-| Stage | Focus | Status in this repo |
+| Phase | Focus | Status in this repo |
 |-------|--------|---------------------|
-| 5 | Distributed store, shared quarantine, cluster coordination | **In progress** — Redis quarantine read/write + validation + cluster throttle + **optional training candidate export** (5.5); not Phase-5-complete (no trainer/registry/full Kafka lifecycle) |
-| 6 | Research, benchmarks, publications | Not started |
+| 5 | Distributed coordination, training pipeline, trainer, model registry | **Largely complete** (5.3–5.6); multi-JVM automated validation still a gap |
+| 6 | Hyperparameter tuning, alternative model types, operational tooling | Not started |
 
-Deferred items and Phase 5 boundaries are summarized in this README; longer design notes may exist only in a local **`docs/`** copy (not versioned here).
+### Phase 5 notes (brief)
 
-### Phase 5.3 — Distributed validation
+- **5.3 — Validation** — Integration tests under `io.aisentinel.validation.*` use Testcontainers Redis and **single-JVM** setups; Docker required when not skipped. No two-JVM CI suite yet. Details: [`ARCHITECTURE.md`](ARCHITECTURE.md) §14.
+- **5.4 — Cluster throttle** — Redis fixed-window counter on the **THROTTLE** path only; fail-open; metrics `aisentinel.distributed.throttle.*`. See [`docs/configuration.md`](docs/configuration.md) for properties.
+- **5.5 — Training publish** — Async `TrainingCandidateRecord` export (log or Kafka). See [`ARCHITECTURE.md`](ARCHITECTURE.md) §10.
+- **5.6 — Trainer + registry** — [`ai-sentinel-trainer/README.md`](ai-sentinel-trainer/README.md); serving nodes refresh via `ModelRefreshScheduler`.
 
-This milestone is **verification**, not new product features. Automated coverage in `ai-sentinel-spring-boot-starter` includes:
+---
 
-- **Scope (important):** All Phase 5.3 Testcontainers tests run in a **single JVM** and **one Spring `ApplicationContext`**. “Node A” is the wired `CompositeEnforcementHandler` plus the primary `StringRedisTemplate`. “Node B” is modeled with a **second `LettuceConnectionFactory` / `StringRedisTemplate`** to the **same** Redis server, a **new** `RedisClusterQuarantineReader` (separate local cache and `DistributedQuarantineStatus`), and—where enforcement is asserted—a separately built `ClusterAwareEnforcementHandler` + `SentinelPipeline` + `SentinelFilter` over `MockMvc`. There is **no automated two-process / two-JVM** test in CI yet.
-- **Distributed enforcement E2E (Docker):** `DistributedQuarantineValidationTest#nodeAWritesQuarantine_nodeBClusterAwareFilterBlocksHttp` — Node A publishes quarantine to Redis; Node B’s pipeline uses `ClusterAwareEnforcementHandler` with **empty local** quarantine maps; an HTTP GET through `SentinelFilter` receives the configured block status (default **429**) and body **Quarantined**, proving cluster state affects **enforcement**, not only `quarantineUntil`.
-- **Read-path + metrics (Docker):** `DistributedQuarantineValidationTest#nodeAQuarantineWritesRedis_nodeBReaderSeesClusterQuarantine_separateRedisClient_metricDeltas` — second Redis client + reader; **Micrometer counter deltas** (write attempts/successes, lookups) and `redisWriterDegraded == false` on the shared status bean after a successful publish/read (baselines captured per test).
-- **CI / Docker:** Testcontainers Redis tests are **skipped** when Docker is unavailable (`@Testcontainers(disabledWithoutDocker = true)`). To exercise them in CI, run with a Docker-capable agent (or accept skips).
-- **Redis unavailable:** `DistributedQuarantineRedisFailureTest` — reader fail-open; writer async failure; local quarantine preserved; unreachable Redis port chosen dynamically via `ServerSocket(0)` (no hardcoded port).
-- **Slow Redis vs lookup budget:** **Unit-only:** `RedisClusterQuarantineReaderTest#failOpenOnTimeout` (mocked slow `GET`). There is **no** integration test that delays real Lettuce I/O against Testcontainers Redis; align `spring.data.redis.timeout` with `lookup-timeout` in production (see table above).
-- **Dropped writes:** `RedisClusterQuarantineWriterTest#secondPublishDroppedWhileFirstWriteBlocksRedis` plus `DistributedQuarantineDroppedWriteCompositeTest`.
-- **Cache staleness:** `DistributedQuarantineValidationTest#cacheServesStalePositiveUntilRedisKeyDeletedThenExpiresAndFailsOpen`.
-- **Actuator shape:** `DistributedQuarantineValidationTest#actuatorExposesDistributedFlagsAndMetricSummary`.
+## Current limitations
 
-**Guarantees reinforced by 5.3:** local quarantine remains authoritative; cluster view is additive; Redis is optional; read and write paths stay fail-open; publish path does not block on Redis I/O; bounded in-flight writes can drop excess work with observability.
+- **Filesystem model registry** only (no built-in S3/Redis artifact store in this repo).
+- **Trainer `eventId` dedup** is JVM-local; multiple trainer instances are not coordinated.
+- **Multi-JVM / multi-process** validation for cluster features is not fully automated in CI.
+- **Registry disk** — no automatic artifact cleanup; operators manage retention.
 
-**Still not implemented:** Kafka training pipeline, trainer service, model registry, automated multi-JVM throttle validation, and other Phase 5 items called out above.
+---
 
-**Optional manual two-instance check:** start Redis (`docker compose up -d` using repo-root `docker-compose.yml` if you use it), run two JVMs (e.g. two terminals with `mvn -pl ai-sentinel-demo spring-boot:run` on different `server.port` values) with the same `spring.data.redis.*` and `ai.sentinel.distributed.*` settings, trigger `QUARANTINE` on instance A, then call an endpoint on instance B with the same identity and confirm cluster quarantine merges into enforcement when read path is enabled.
+## Security
 
-### Phase 5.4 — Distributed throttling (high-risk / THROTTLE path)
-
-**What it does:** When policy maps a request to **THROTTLE**, `CompositeEnforcementHandler` first consults an optional **Redis fixed-window counter** per tenant + enforcement key (`identity|endpoint` or identity-only per `enforcement-scope`), then applies the existing **local** token bucket. That closes the “rotate across nodes to reset throttle” gap for suspicious traffic **without** turning Redis into a global limiter for all requests.
-
-**What it does not do:** It is **not** cluster rate limiting for ALLOW/MONITOR traffic, **not** applied on BLOCK/QUARANTINE paths, and **not** a precise distributed token-bucket—just a bounded **INCR** per window with TTL.
-
-**Burst / window boundary:** Redis **INCR** is atomic. Under concurrent load, at most **`cluster-throttle-max-requests-per-window`** evaluations can observe a counter value ≤ that cap (cluster **allow**); additional evaluations in the same window observe a higher count and are **cluster-rejected** (`tryAcquire` returns false) unless a fail-open path applies (timeout, Redis error, in-flight cap). Near a window rollover, a short period can admit up to **2× max** cluster-side (last slots of bucket *N* and first slots of bucket *N+1*)—local throttle still applies afterward.
-
-**Semantics:** Fail-open on Redis down/slow/errors, executor/semaphore saturation, or timeout (request continues; local throttle may still apply). The JVM holds a bounded number of in-flight throttle Redis tasks (`cluster-throttle-max-in-flight`); excess attempts fail-open with reason **`inflight_exhausted`**.
-
-**Metrics (Micrometer / Prometheus):**
-
-| Meter | Meaning |
-|-------|---------|
-| `aisentinel.distributed.throttle.evaluation` | Throttle path invoked cluster check |
-| `aisentinel.distributed.throttle.allow` | Counter ≤ cap (cluster allows) |
-| `aisentinel.distributed.throttle.reject` | Counter &gt; cap (cluster rejects) |
-| `aisentinel.distributed.throttle.redis.timeout` | Future timed out waiting for Redis |
-| `aisentinel.distributed.throttle.redis.failure` | Redis/command failure on completed wait |
-| `aisentinel.distributed.throttle.executor.rejected` | In-flight semaphore full or executor rejected async work |
-| `aisentinel.distributed.throttle.redis.eval` | Timer for eval wall time |
-
-Actuator **`distributedThrottle`** exposes `redisThrottleDegraded` and `lastRedisErrorSummary` with reason prefixes: `redis_timeout`, `redis_failure`, `inflight_exhausted`, `executor_rejected`.
-
-**Still deferred:** Automated multi-JVM throttle validation beyond current starter tests (burst, timeout, recovery, in-flight saturation).
-
-### Phase 5.5 — Training candidate publishing
-
-**What it does:** After policy and enforcement complete, the pipeline can **offer** a bounded, versioned **`TrainingCandidateRecord`** (schema v2: **`eventId`**, SHA-256 **fingerprints** for endpoint and enforcement-key material, numeric feature snapshots, scores, policy outcome) to an async publisher. **Raw request paths and composite enforcement keys are not exported** (only stable hashes of the same strings used locally). Default transport is a single **JSON log line** at INFO; optional **Kafka** when `spring-kafka` is on the classpath, `KafkaTemplate` exists, and `training-kafka-enabled=true`.
-
-**What it does not do:** No on-request training, no trainer consumer, no model registry, no change to policy or enforcement outcomes.
-
-**Hook:** `SentinelPipeline` calls `TrainingCandidatePublisher.publish` after `enforcementHandler.apply` returns; the request thread runs cheap gates, **copies feature arrays**, computes hashes, builds the record, `Semaphore.tryAcquire`, and schedules work; transport I/O runs on virtual-thread workers.
-
-**Bounded / fail-open:** Score floor and optional IF anti-poisoning run before sampling; **stratified sampling** (default on) lets high composite scores bypass the uniform sample so rare high-risk rows are not starved; in-flight cap with **drop + metric**, executor reject handling, transport errors recorded without affecting the HTTP path.
-
-**Metrics:** `aisentinel.distributed.training.publish.*` (attempt, success, failure, **failure.timeout**, **failure.serialization**, dropped, skipped_sample, skipped_gate, executor_rejected, unexpected_failure), **`aisentinel.distributed.training.publish.transport`** timer; gauge `aisentinel.distributed.training.publish.degraded` when status bean is present. Actuator: `distributedTrainingPublishMetrics`, `trainingPublish`, flags for publish/Kafka/topic.
-
-### Phase 5.6 — Trainer + filesystem model registry / rollout
-
-**Trainer module (`ai-sentinel-trainer`):** Separate Spring Boot app that optionally consumes **Kafka** (`aisentinel.trainer.kafka.enabled=true`) from the same topic as Phase 5.5, parses **schema v2** JSON, applies **bounded** FIFO buffering and **admission** gates (tenant match, composite floor, optional IF-score anti-poisoning), trains an **Isolation Forest** with the same in-core trainer, and **atomically publishes** `{version}.meta.json` + `{version}.payload.bin` plus `active.json` under `aisentinel.trainer.registry.filesystem-root` / tenant. A train cycle **drains** the buffer into a snapshot so samples arriving **during** training remain in the buffer; failed cycles **restore** the drained snapshot. **Bounded** in-memory dedup of `eventId` (default 50_000; `aisentinel.trainer.dedup.max-recent-event-ids`, `0` disables) drops duplicates with metric **`aisentinel.trainer.candidates.duplicate_event_id`**; wrong-tenant records increment **`aisentinel.trainer.candidates.wrong_tenant`**. Dedup is **process-local** only (restarts and new trainer instances can see duplicates again).
-
-**Serving nodes (starter):** When `isolation-forest.enabled`, `model-registry.refresh-enabled`, and a non-empty **`model-registry.filesystem-root`** are set, `ModelRefreshScheduler` runs an **immediate** off-thread refresh tick at startup, then polls **`active.json`** on the configured interval, loads metadata + payload **off-request**, verifies **SHA-256**, decodes **`AIF1` binary codec**, and calls **`IsolationForestScorer.tryInstallFromRegistry`**. Failures keep the **last-known-good** volatile model; HTTP handling is unaffected.
-
-**Local retrain vs registry (single writer):** When registry refresh is fully wired (`refresh-enabled` + non-empty `filesystem-root`), **`IsolationForestRetrainScheduler` is not registered** so it cannot race `ModelRefreshScheduler`. For standalone nodes using only the in-process buffer, keep `model-registry.refresh-enabled=false` (or leave `filesystem-root` unset) so local retrain runs. Property **`ai.sentinel.isolation-forest.local-retrain-enabled`** (default `true`) disables local retrain when set to `false`. **Authoritative model source** on a node is either registry-installed or locally retrained, never both schedulers at once in a correctly configured deployment.
-
-**Artifact format:** Canonical **`io.aisentinel.model.ModelArtifactMetadata`** (artifact schema v1, type `isolation_forest_v1`) + binary **`IsolationForestModelCodec`** payload (max 16 MiB). Checksum over payload bytes is mandatory before swap.
-
-**Rollback:** Operators point `active.json` at a previous `modelVersion` whose files remain under `artifacts/`; the next poll installs that version if checksums match.
-
-**Observability:** Micrometer `aisentinel.model.registry.*` on nodes; gauge **`aisentinel.isolation_forest.model.source`** (ordinal: `0` = none, `1` = local retrain, `2` = registry); actuator **`modelRegistryMetrics`**, **`modelRegistryArtifactVersion`**, install failure counts. No request-path registry or trainer calls.
-
-**Registry retention:** The filesystem registry **does not** expire old artifact files automatically; operators should plan disk retention or external cleanup.
-
-**Not in this milestone:** Central inference service, Redis-backed registry (filesystem only), schema registry product, Phase 6 hyperparameter / research tooling.
+**[`SECURITY.md`](SECURITY.md)** — reporting and design assumptions.
 
 ---
 
 ## Contributing
 
-- Match existing code style and Maven module boundaries.
-- Run **`mvn test`** before submitting changes.
-- Prefer factual, concise documentation updates alongside behavior changes.
+Development happens on the **`dev`** branch — see [`CONTRIBUTING.md`](CONTRIBUTING.md) for the branching workflow, layout, tests, PR expectations, and project invariants.
+
+- Match existing style and module boundaries.
+- Run **`mvn test`** before submitting.
+- Update docs when behavior or configuration changes.
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,38 @@
+# Security
+
+## Supported versions
+
+Security fixes are developed on **`dev`** and promoted to **`main`** via the normal release flow. Critical vulnerabilities that require immediate public mitigation may be hotfixed directly on `main` at maintainer discretion; such fixes are merged back into `dev` promptly.
+
+Use the latest commit or release tag for deployments. Older snapshots are not maintained on a separate long-term support schedule unless explicitly stated in the future.
+
+---
+
+## Reporting vulnerabilities
+
+**Please do not** open public GitHub issues for unfixed vulnerability details.
+
+- Report privately to the repository maintainers (use **GitHub Security Advisories** / **private security reporting** if enabled on the repo, or contact addresses listed in repository settings or maintainer profiles).
+- Include: affected component, version or commit, reproduction steps, and impact assessment if you can.
+
+Maintainers will acknowledge receipt when possible and coordinate a fix and disclosure timeline. This is a volunteer-driven open-source project; response times are best-effort, not a SLA.
+
+---
+
+## Security-related design choices
+
+- **Fail-open** — Many optional paths (e.g. distributed Redis, async training publish) are designed so failures degrade to permissive behavior where documented, to avoid accidental total outage. This trades strict lockdown for availability; operators must tune flags and monitor metrics.
+- **No raw PII in training/export** — Training candidate records use hashed fingerprints and numeric features, not raw URLs or bodies. See Phase 5.5 documentation in the root [`README.md`](README.md).
+- **Identity as hash** — Features and enforcement keys use hashed identifiers; configure hashing and trust boundaries in your application.
+- **Bounded processing** — Buffers, semaphores, and timeouts limit work on hot and async paths; they are not a substitute for network-level rate limiting or auth.
+
+---
+
+## Known limitations
+
+- **Not a full WAF or IAM product** — AI-Sentinel complements auth and infrastructure controls; it does not replace them.
+- **Distributed features depend on Redis/Kafka** — Misconfiguration, credential leaks, or broker compromise are outside this library’s scope; follow standard practices for secrets and network policy.
+- **Filesystem model registry** — Phase 5.6 uses a shared filesystem layout; OS permissions and shared mounts are your responsibility.
+- **Trainer dedup is JVM-local** — Duplicate `eventId` handling does not survive process restarts or multiple trainer instances without external coordination.
+
+No security boundary is perfect; review changes in your own threat model before production use.

--- a/ai-sentinel-core/README.md
+++ b/ai-sentinel-core/README.md
@@ -1,0 +1,7 @@
+# ai-sentinel-core
+
+Framework-agnostic engine: **`SentinelPipeline`** (feature extract → score → policy → enforce → telemetry), scorers, policy, enforcement handlers, optional training-export contracts, and **`io.aisentinel.model`** types for registry artifacts.
+
+No Spring dependency in this module. Consumed by **`ai-sentinel-spring-boot-starter`** and **`ai-sentinel-trainer`**.
+
+**Next:** [Root README](../README.md) · [Architecture](../ARCHITECTURE.md) §3–7, §10 (distributed), §12 (extension points).

--- a/ai-sentinel-core/src/main/java/io/aisentinel/core/SentinelPipeline.java
+++ b/ai-sentinel-core/src/main/java/io/aisentinel/core/SentinelPipeline.java
@@ -22,7 +22,11 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
 
 /**
- * Orchestrates feature extraction, scoring, policy, and enforcement.
+ * Central orchestration of feature extraction, scoring, policy, enforcement, telemetry, metrics, and optional
+ * training export. Invoked from the servlet filter (Spring Boot starter) on each request.
+ * <p>
+ * Request-path invariants: scoring and policy run synchronously; training publish is async and fail-open; failures in
+ * scoring may fail-open per pipeline logic without blocking indefinitely.
  */
 @Slf4j
 public final class SentinelPipeline {

--- a/ai-sentinel-core/src/main/java/io/aisentinel/core/enforcement/EnforcementHandler.java
+++ b/ai-sentinel-core/src/main/java/io/aisentinel/core/enforcement/EnforcementHandler.java
@@ -6,8 +6,13 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
 /**
- * Applies an enforcement action to the request/response.
- * Returns true if the request should proceed (doFilter), false if response was already written.
+ * Applies {@link EnforcementAction} to the HTTP request/response (throttle, block, quarantine, etc.).
+ * <p>
+ * Runs on the request path. Local maps (throttle/quarantine) are the <strong>source of truth</strong> for
+ * {@link #apply}; optional cluster merges are additive in {@link io.aisentinel.distributed.enforcement.ClusterAwareEnforcementHandler}.
+ * Implementations must not block indefinitely on remote I/O.
+ *
+ * @return {@code true} if the filter chain should continue; {@code false} if the response was already committed
  */
 public interface EnforcementHandler {
 
@@ -15,7 +20,9 @@ public interface EnforcementHandler {
                   String identityHash, String endpoint);
 
     /**
-     * @param endpoint request path or normalized endpoint; used when enforcement scope is per-endpoint.
+     * Whether the identity (and endpoint) is under active quarantine for {@code isQuarantined} checks.
+     *
+     * @param endpoint request path or normalized endpoint; used when enforcement scope is per-endpoint
      */
     default boolean isQuarantined(String identityHash, String endpoint) {
         return false;

--- a/ai-sentinel-core/src/main/java/io/aisentinel/core/enforcement/package-info.java
+++ b/ai-sentinel-core/src/main/java/io/aisentinel/core/enforcement/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Enforcement handlers: local throttle/quarantine/block maps; optional wrappers for cluster quarantine merge.
+ * Local enforcement remains authoritative; cluster state is additive.
+ */
+package io.aisentinel.core.enforcement;

--- a/ai-sentinel-core/src/main/java/io/aisentinel/core/feature/FeatureExtractor.java
+++ b/ai-sentinel-core/src/main/java/io/aisentinel/core/feature/FeatureExtractor.java
@@ -6,13 +6,22 @@ import jakarta.servlet.http.HttpServletRequest;
 
 /**
  * Extracts privacy-aware numeric features from an HTTP request.
+ * <p>
+ * Runs on the <strong>request path</strong> inside {@link io.aisentinel.core.SentinelPipeline}. Implementations must be
+ * thread-safe and should not perform network I/O; state must remain bounded (see {@link #metricsEndpointHistoryEntryCount}).
  */
 public interface FeatureExtractor {
 
+    /**
+     * @param request      current HTTP request
+     * @param identityHash stable hash of identity (never raw PII)
+     * @param ctx          optional request context
+     * @return immutable feature vector for scoring
+     */
     RequestFeatures extract(HttpServletRequest request, String identityHash, RequestContext ctx);
 
     /**
-     * Size of extractor-internal caches for metrics (e.g. endpoint history). Default none.
+     * Approximate size of extractor-internal caches for actuator/metrics (e.g. endpoint history). Default none.
      */
     default int metricsEndpointHistoryEntryCount() {
         return 0;

--- a/ai-sentinel-core/src/main/java/io/aisentinel/core/feature/package-info.java
+++ b/ai-sentinel-core/src/main/java/io/aisentinel/core/feature/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * {@link io.aisentinel.core.feature.FeatureExtractor} and default implementation: privacy-oriented request features
+ * for scoring (bounded state, no raw bodies in vectors).
+ */
+package io.aisentinel.core.feature;

--- a/ai-sentinel-core/src/main/java/io/aisentinel/core/package-info.java
+++ b/ai-sentinel-core/src/main/java/io/aisentinel/core/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Framework-agnostic Sentinel engine: {@link io.aisentinel.core.SentinelPipeline} coordinates feature extraction,
+ * scoring, policy, enforcement, telemetry, and optional training export. No Spring dependencies in this package.
+ */
+package io.aisentinel.core;

--- a/ai-sentinel-core/src/main/java/io/aisentinel/core/policy/PolicyEngine.java
+++ b/ai-sentinel-core/src/main/java/io/aisentinel/core/policy/PolicyEngine.java
@@ -3,9 +3,19 @@ package io.aisentinel.core.policy;
 import io.aisentinel.core.model.RequestFeatures;
 
 /**
- * Maps risk score to enforcement action.
+ * Maps a single composite risk score (0–1) to an {@link EnforcementAction}.
+ * <p>
+ * Invoked on the request path after scoring. Implementations must be side-effect free and non-blocking; local
+ * enforcement policy remains authoritative (cluster views are merged in the handler layer, not here).
  */
 public interface PolicyEngine {
 
+    /**
+     * @param riskScore    composite score in {@code [0.0, 1.0]} (may be NaN or out of range in edge cases; callers
+     *                     may clamp before policy)
+     * @param features     request features (for future policy extensions)
+     * @param endpoint     normalized request path or endpoint key
+     * @return enforcement action to apply
+     */
     EnforcementAction evaluate(double riskScore, RequestFeatures features, String endpoint);
 }

--- a/ai-sentinel-core/src/main/java/io/aisentinel/core/policy/package-info.java
+++ b/ai-sentinel-core/src/main/java/io/aisentinel/core/policy/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * {@link io.aisentinel.core.policy.PolicyEngine} and threshold implementation: maps composite score to
+ * {@link io.aisentinel.core.policy.EnforcementAction}.
+ */
+package io.aisentinel.core.policy;

--- a/ai-sentinel-core/src/main/java/io/aisentinel/core/runtime/StartupGrace.java
+++ b/ai-sentinel-core/src/main/java/io/aisentinel/core/runtime/StartupGrace.java
@@ -1,12 +1,17 @@
 package io.aisentinel.core.runtime;
 
 /**
- * Indicates whether the JVM is still within a configurable startup grace window.
- * During grace, the pipeline should apply reduced enforcement (typically MONITOR-only).
+ * Indicates whether the JVM is still within a configurable post-startup window where enforcement may be relaxed.
+ * <p>
+ * Read on the request path during pipeline processing. {@link #isGraceActive} should be cheap (typically a time
+ * comparison). When grace is active, the pipeline typically applies {@link io.aisentinel.core.enforcement.CompositeEnforcementHandler}
+ * behavior in a monitor-oriented way (see {@link io.aisentinel.core.SentinelPipeline}).
  */
 public interface StartupGrace {
 
+    /** Never grants grace (always {@code false}). */
     StartupGrace NEVER = () -> false;
 
+    /** {@code true} while the grace window has not elapsed; {@code false} after. */
     boolean isGraceActive();
 }

--- a/ai-sentinel-core/src/main/java/io/aisentinel/core/scoring/AnomalyScorer.java
+++ b/ai-sentinel-core/src/main/java/io/aisentinel/core/scoring/AnomalyScorer.java
@@ -3,12 +3,28 @@ package io.aisentinel.core.scoring;
 import io.aisentinel.core.model.RequestFeatures;
 
 /**
- * Computes an anomaly score for request features.
- * Score is normalized to [0.0, 1.0] where higher = more anomalous.
+ * Computes a per-request anomaly sub-score from {@link RequestFeatures}.
+ * <p>
+ * Used on the <strong>request path</strong> inside {@link io.aisentinel.core.SentinelPipeline}. Implementations must be
+ * thread-safe for concurrent {@link #score} / {@link #update} calls and should avoid blocking I/O. Scores returned from
+ * {@link #score} are expected in {@code [0.0, 1.0]} (higher = more anomalous); NaN or negative values may be clamped
+ * downstream by the composite scorer.
  */
 public interface AnomalyScorer {
 
+    /**
+     * Produce a blended or per-model score for policy evaluation.
+     *
+     * @param features features for the current request (must not be mutated)
+     * @return anomaly score in {@code [0.0, 1.0]} under normal conditions
+     */
     double score(RequestFeatures features);
 
+    /**
+     * Optional training / online update: sample a subset of traffic for bounded buffers (e.g. Isolation Forest).
+     * Must be cheap; must not block the request thread on network I/O.
+     *
+     * @param features same request as {@link #score}
+     */
     void update(RequestFeatures features);
 }

--- a/ai-sentinel-core/src/main/java/io/aisentinel/core/scoring/package-info.java
+++ b/ai-sentinel-core/src/main/java/io/aisentinel/core/scoring/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Anomaly scorers (statistical Welford, optional Isolation Forest), composite blending, bounded training buffers,
+ * and model codec types used on the request path and by background retrain/registry install.
+ */
+package io.aisentinel.core.scoring;

--- a/ai-sentinel-core/src/main/java/io/aisentinel/core/telemetry/TelemetryEmitter.java
+++ b/ai-sentinel-core/src/main/java/io/aisentinel/core/telemetry/TelemetryEmitter.java
@@ -1,9 +1,16 @@
 package io.aisentinel.core.telemetry;
 
 /**
- * Emits telemetry events (fire-and-forget; failures must not affect request processing).
+ * Emits structured telemetry for observability (logging, audit).
+ * <p>
+ * Called from the request path after scoring/enforcement. Implementations must treat emission as
+ * <strong>best-effort</strong>: {@link #emit} must not throw or block indefinitely; failures must not change policy
+ * or enforcement outcomes.
  */
 public interface TelemetryEmitter {
 
+    /**
+     * Fire-and-forget event. Must not throw checked exceptions; unchecked failures should be swallowed or logged.
+     */
     void emit(TelemetryEvent event);
 }

--- a/ai-sentinel-core/src/main/java/io/aisentinel/core/telemetry/TelemetryEvent.java
+++ b/ai-sentinel-core/src/main/java/io/aisentinel/core/telemetry/TelemetryEvent.java
@@ -2,6 +2,9 @@ package io.aisentinel.core.telemetry;
 
 import java.util.Map;
 
+/**
+ * Immutable telemetry payload for {@link TelemetryEmitter}. Factory methods mask identity hashes in log output.
+ */
 public record TelemetryEvent(
     String type,
     long timestampMillis,

--- a/ai-sentinel-core/src/main/java/io/aisentinel/core/telemetry/package-info.java
+++ b/ai-sentinel-core/src/main/java/io/aisentinel/core/telemetry/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * {@link io.aisentinel.core.telemetry.TelemetryEmitter} and events: best-effort structured logging after
+ * scoring/enforcement (must not affect policy outcomes).
+ */
+package io.aisentinel.core.telemetry;

--- a/ai-sentinel-core/src/main/java/io/aisentinel/distributed/package-info.java
+++ b/ai-sentinel-core/src/main/java/io/aisentinel/distributed/package-info.java
@@ -1,6 +1,7 @@
 /**
- * Phase 5 — distributed coordination contracts (quarantine visibility, training export, model metadata).
+ * Distributed coordination contracts: cluster quarantine, throttle, training export (interfaces and DTOs).
  * <p>
- * Default implementations are no-ops. Redis/Kafka integrations live in the Spring Boot starter (optional).
+ * Default implementations are no-ops where applicable; Redis/Kafka-backed beans are wired from the Spring Boot starter
+ * when enabled. Scoring and local enforcement remain authoritative; distributed views are additive and fail-open.
  */
 package io.aisentinel.distributed;

--- a/ai-sentinel-core/src/main/java/io/aisentinel/distributed/training/TrainingCandidatePublisher.java
+++ b/ai-sentinel-core/src/main/java/io/aisentinel/distributed/training/TrainingCandidatePublisher.java
@@ -1,12 +1,15 @@
 package io.aisentinel.distributed.training;
 
 /**
- * Exports training candidates asynchronously. Implementations must not block the request thread and must fail-open.
+ * Offers training candidates for export after enforcement (Phase 5.5). Implementations must <strong>not</strong> block
+ * the request thread; must use bounded queues and fail-open if overloaded or broken.
  */
 public interface TrainingCandidatePublisher {
 
     /**
-     * Invoked after enforcement has been applied. Must return quickly; heavy or I/O work belongs on a bounded worker.
+     * Called after enforcement completes. Must return quickly; serialization and transport run on a worker.
+     * <p>
+     * On failure, the HTTP response must already be committed; export failures are metrics-only.
      */
     void publish(TrainingCandidatePublishRequest request);
 }

--- a/ai-sentinel-core/src/main/java/io/aisentinel/model/ModelRegistryReader.java
+++ b/ai-sentinel-core/src/main/java/io/aisentinel/model/ModelRegistryReader.java
@@ -3,8 +3,10 @@ package io.aisentinel.model;
 import java.util.Optional;
 
 /**
- * Read-only registry view for serving nodes: resolve which artifact is active and fetch bytes.
- * Implementations must be fail-safe for the caller (no exceptions on missing files).
+ * Read-only registry view for serving nodes: resolve which artifact is active and fetch payload bytes.
+ * <p>
+ * Used from <strong>background</strong> threads (model refresh schedulers), not from the servlet thread.
+ * Implementations must be fail-safe for the caller (return empty {@link Optional}, do not throw for missing files).
  */
 public interface ModelRegistryReader {
 

--- a/ai-sentinel-core/src/main/java/io/aisentinel/model/package-info.java
+++ b/ai-sentinel-core/src/main/java/io/aisentinel/model/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Model artifact metadata and {@link io.aisentinel.model.ModelRegistryReader} SPI for filesystem-based
+ * registry layouts (read off the request thread by serving nodes).
+ */
+package io.aisentinel.model;

--- a/ai-sentinel-demo/README.md
+++ b/ai-sentinel-demo/README.md
@@ -1,0 +1,7 @@
+# ai-sentinel-demo
+
+Minimal Spring Boot app (`/api/hello`) with the starter on the classpath and actuator exposed—used for smoke tests (**`DemoIntegrationTest`**) and local manual runs.
+
+Optional **`stage2`** profile speeds Isolation Forest training for experiments (`application-stage2.yaml`).
+
+**Next:** [Root README](../README.md) · run from repo root: `mvn -pl ai-sentinel-demo spring-boot:run`.

--- a/ai-sentinel-spring-boot-starter/README.md
+++ b/ai-sentinel-spring-boot-starter/README.md
@@ -1,0 +1,7 @@
+# ai-sentinel-spring-boot-starter
+
+Spring Boot auto-configuration: **`SentinelFilter`**, **`SentinelAutoConfiguration`**, **`SentinelProperties`** (`ai.sentinel.*`), actuator **`/actuator/sentinel`**, Micrometer **`MicrometerSentinelMetrics`**, and optional distributed / filesystem model-registry beans.
+
+Depends only on **`ai-sentinel-core`**.
+
+**Next:** [Root README](../README.md) · [Configuration](../docs/configuration.md) · [Architecture](../ARCHITECTURE.md) §9–10, §13–14.

--- a/ai-sentinel-spring-boot-starter/src/main/java/io/aisentinel/autoconfigure/actuator/SentinelActuatorEndpoint.java
+++ b/ai-sentinel-spring-boot-starter/src/main/java/io/aisentinel/autoconfigure/actuator/SentinelActuatorEndpoint.java
@@ -26,6 +26,10 @@ import org.springframework.beans.factory.ObjectProvider;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
+/**
+ * Actuator endpoint {@code /actuator/sentinel}: read-only operational snapshot (config flags, IF state, distributed
+ * health, recent score components, Micrometer summaries when available).
+ */
 @Slf4j
 @Endpoint(id = "sentinel")
 public class SentinelActuatorEndpoint {

--- a/ai-sentinel-spring-boot-starter/src/main/java/io/aisentinel/autoconfigure/config/SentinelAutoConfiguration.java
+++ b/ai-sentinel-spring-boot-starter/src/main/java/io/aisentinel/autoconfigure/config/SentinelAutoConfiguration.java
@@ -52,6 +52,14 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.context.annotation.Conditional;
+
+/**
+ * Primary Spring Boot auto-configuration for AI-Sentinel: pipeline beans, filter, optional Isolation Forest and
+ * distributed features. Most beans use {@link ConditionalOnMissingBean} so applications can override extension points
+ * ({@link io.aisentinel.core.feature.FeatureExtractor}, {@link io.aisentinel.core.policy.PolicyEngine}, etc.).
+ * <p>
+ * Model registry refresh is registered separately in {@link io.aisentinel.autoconfigure.model.ModelRegistryAutoConfiguration}.
+ */
 @Slf4j
 @AutoConfiguration
 @ConditionalOnWebApplication

--- a/ai-sentinel-spring-boot-starter/src/main/java/io/aisentinel/autoconfigure/config/SentinelProperties.java
+++ b/ai-sentinel-spring-boot-starter/src/main/java/io/aisentinel/autoconfigure/config/SentinelProperties.java
@@ -16,6 +16,10 @@ import org.springframework.validation.annotation.Validated;
 import java.time.Duration;
 import java.util.List;
 
+/**
+ * Binds {@code ai.sentinel.*} configuration (thresholds, isolation forest, distributed, model registry).
+ * Validated at startup where constraints apply.
+ */
 @Data
 @Validated
 @ConfigurationProperties(prefix = "ai.sentinel")

--- a/ai-sentinel-spring-boot-starter/src/main/java/io/aisentinel/autoconfigure/config/package-info.java
+++ b/ai-sentinel-spring-boot-starter/src/main/java/io/aisentinel/autoconfigure/config/package-info.java
@@ -1,0 +1,6 @@
+/**
+ * Spring Boot auto-configuration: {@link io.aisentinel.autoconfigure.config.SentinelAutoConfiguration},
+ * {@link io.aisentinel.autoconfigure.config.SentinelProperties} ({@code ai.sentinel.*}), and conditional beans
+ * for extension points.
+ */
+package io.aisentinel.autoconfigure.config;

--- a/ai-sentinel-spring-boot-starter/src/main/java/io/aisentinel/autoconfigure/distributed/training/TrainingCandidateTransport.java
+++ b/ai-sentinel-spring-boot-starter/src/main/java/io/aisentinel/autoconfigure/distributed/training/TrainingCandidateTransport.java
@@ -3,9 +3,19 @@ package io.aisentinel.autoconfigure.distributed.training;
 import io.aisentinel.distributed.training.TrainingCandidateRecord;
 
 /**
- * Blocking send of a serialized candidate; invoked from a bounded worker thread only.
+ * Serializes and sends a {@link TrainingCandidateRecord} to a destination (Kafka, log shipper, etc.).
+ * <p>
+ * Not called from the servlet thread: the async publisher invokes this from a <strong>bounded worker pool</strong>.
+ * Implementations may block for I/O; failures should be reported via metrics and surfaced to callers as exceptions
+ * where the worker handles them without affecting the HTTP response.
  */
 public interface TrainingCandidateTransport {
 
+    /**
+     * Send one record. May block until the transport accepts or fails the send.
+     *
+     * @param record bounded, versioned payload (no raw PII)
+     * @throws Exception on unrecoverable transport failure (worker records metrics; request path is unaffected)
+     */
     void send(TrainingCandidateRecord record) throws Exception;
 }

--- a/ai-sentinel-spring-boot-starter/src/main/java/io/aisentinel/autoconfigure/model/ModelRefreshScheduler.java
+++ b/ai-sentinel-spring-boot-starter/src/main/java/io/aisentinel/autoconfigure/model/ModelRefreshScheduler.java
@@ -15,8 +15,9 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
 /**
- * Off-request poll of {@link ModelRegistryReader}; installs newer artifacts via
- * {@link IsolationForestScorer#tryInstallFromRegistry} without blocking HTTP handling.
+ * Background poll of {@link ModelRegistryReader} to install newer Isolation Forest artifacts via
+ * {@link IsolationForestScorer#tryInstallFromRegistry}. Runs on a dedicated scheduler thread—<strong>never</strong> on
+ * the servlet thread. Failures keep the last-known-good model (fail-open for inference).
  */
 @Slf4j
 public final class ModelRefreshScheduler implements DisposableBean {

--- a/ai-sentinel-spring-boot-starter/src/main/java/io/aisentinel/autoconfigure/web/SentinelFilter.java
+++ b/ai-sentinel-spring-boot-starter/src/main/java/io/aisentinel/autoconfigure/web/SentinelFilter.java
@@ -19,6 +19,10 @@ import java.security.NoSuchAlgorithmException;
 import java.nio.charset.StandardCharsets;
 import java.util.HexFormat;
 
+/**
+ * Servlet filter that runs the {@link io.aisentinel.core.SentinelPipeline} once per request (after auth when ordered late).
+ * Respects {@link io.aisentinel.autoconfigure.config.SentinelProperties#getExcludePaths()} and mode OFF/MONITOR/ENFORCE.
+ */
 @Slf4j
 @Order(Ordered.LOWEST_PRECEDENCE - 100)
 @RequiredArgsConstructor

--- a/ai-sentinel-spring-boot-starter/src/main/java/io/aisentinel/autoconfigure/web/package-info.java
+++ b/ai-sentinel-spring-boot-starter/src/main/java/io/aisentinel/autoconfigure/web/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Servlet integration: {@link io.aisentinel.autoconfigure.web.SentinelFilter} and {@link io.aisentinel.autoconfigure.web.ClientIpResolver}
+ * (trusted proxy handling).
+ */
+package io.aisentinel.autoconfigure.web;

--- a/ai-sentinel-trainer/README.md
+++ b/ai-sentinel-trainer/README.md
@@ -1,0 +1,88 @@
+# ai-sentinel-trainer
+
+Standalone Spring Boot application that **consumes** training candidates (from Kafka when enabled), **trains** an in-core Isolation Forest model, and **publishes** artifacts to a **filesystem** model registry layout that serving nodes read via `ModelRegistryReader` / `ModelRefreshScheduler`.
+
+---
+
+## Purpose
+
+1. **Consume** JSON lines matching `TrainingCandidateRecord` (schema v2) — the same events Phase 5.5 can publish from starter nodes (`ai.sentinel.distributed.training-publish-enabled`, optional Kafka).
+2. **Train** using the same `IsolationForestTrainer` / codec stack as the core library.
+3. **Publish** `{version}.meta.json`, `{version}.payload.bin`, and `active.json` under `aisentinel.trainer.registry.filesystem-root` / `{tenantId}/`.
+
+This module does **not** run inside your API process; it is a separate deployable.
+
+---
+
+## Relation to Phase 5.5
+
+Starter apps **publish** candidates asynchronously (log or Kafka). **Trainer** is the **consumer** side: when `aisentinel.trainer.kafka.enabled=true` and a broker is configured, it subscribes to `aisentinel.trainer.kafka.topic` (default `aisentinel.training.candidates` — align with `ai.sentinel.distributed.training-candidates-topic` on producers). Without Kafka, the app still starts but **no messages are consumed** unless you extend the codebase.
+
+---
+
+## Architecture (brief)
+
+- **`TrainerKafkaListener`** — `@KafkaListener` when `kafka.enabled=true`.
+- **`TrainerOrchestrator`** — Parses JSON, admission gates, bounded buffer, scheduled train cycle, `FilesystemArtifactPublisher`.
+- **Buffer** — FIFO cap (`buffer.max-samples`); train cycle **drains** for training and restores on failure.
+
+---
+
+## Run
+
+Prerequisites: **Java 21**, **Maven**, root build `mvn clean install` from `ai-sentinel` parent.
+
+```bash
+cd /path/to/ai-sentinel
+mvn -pl ai-sentinel-trainer spring-boot:run
+```
+
+With Kafka (example — set broker and enable the consumer in config):
+
+```bash
+export KAFKA_BOOTSTRAP_SERVERS=localhost:9092
+mvn -pl ai-sentinel-trainer spring-boot:run -Dspring-boot.run.arguments=--aisentinel.trainer.kafka.enabled=true
+```
+
+Or set `aisentinel.trainer.kafka.enabled: true` in `application.yml` / your profile.
+
+Configure `MODEL_REGISTRY_ROOT` or `aisentinel.trainer.registry.filesystem-root` so serving nodes can point `ai.sentinel.model-registry.filesystem-root` at the **same** directory.
+
+---
+
+## Configuration (`aisentinel.trainer.*`)
+
+| Area | Property prefix | Notes |
+|------|-----------------|--------|
+| Tenant | `tenant-id` | Must match producer `ai.sentinel.distributed.tenant-id` for admitted rows. |
+| Registry | `registry.filesystem-root` | Output root (default `./var/aisentinel-model-registry`). |
+| Buffer | `buffer.max-samples` | Max training rows (default 50_000). |
+| Train | `train.interval-millis`, `train.min-samples` | Schedule and minimum buffer size before training. |
+| IF | `if-model.num-trees`, `max-depth`, `random-seed` | Training hyperparameters. |
+| Admission | `admission.min-composite-score`, `max-isolation-forest-score` | Candidate filters. |
+| Dedup | `dedup.max-recent-event-ids` | Bounded `eventId` LRU; `0` disables. |
+| Kafka | `kafka.enabled`, `kafka.topic`, `kafka.group-id` | Consumer wiring. |
+
+Spring Boot also binds `spring.kafka.*` (see `application.yml` for bootstrap defaults).
+
+---
+
+## Metrics (Micrometer)
+
+Prefix **`aisentinel.trainer.`**, including:
+
+- `candidates.received`, `candidates.malformed`, `candidates.admission_rejected`, `candidates.wrong_tenant`, `candidates.duplicate_event_id`
+- `train.success`, `train.failure`, `train.duration`, `artifact.published`
+
+Expose Prometheus if `micrometer-registry-prometheus` is on the classpath (see module `pom.xml`).
+
+---
+
+## Limitations
+
+- **Filesystem registry only** — No built-in S3/Redis artifact store; operators manage disk and permissions.
+- **JVM-local `eventId` dedup** — Restarts and multiple trainer instances can see duplicates; no distributed leader election.
+- **No multi-node trainer coordination** — One trainer instance per logical pipeline is assumed; scale-out requires external design.
+- **Kafka required for live ingestion** — With `kafka.enabled=false`, wire your own feed or enable Kafka for production-style runs.
+
+For end-to-end flow and node-side refresh, see root [`README.md`](../README.md) Phase 5.5 / 5.6 and [`ARCHITECTURE.md`](../ARCHITECTURE.md) §10.

--- a/ai-sentinel-trainer/src/main/java/io/aisentinel/trainer/TrainerApplication.java
+++ b/ai-sentinel-trainer/src/main/java/io/aisentinel/trainer/TrainerApplication.java
@@ -5,6 +5,10 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
+/**
+ * Entry point for the optional {@code ai-sentinel-trainer} Spring Boot app: consumes training candidates (Kafka when
+ * enabled), trains IF models, publishes to a filesystem registry—separate from serving nodes.
+ */
 @SpringBootApplication
 @ConfigurationPropertiesScan
 @EnableScheduling

--- a/ai-sentinel-trainer/src/main/java/io/aisentinel/trainer/TrainerConfig.java
+++ b/ai-sentinel-trainer/src/main/java/io/aisentinel/trainer/TrainerConfig.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+/** Minimal trainer wiring (e.g. shared {@link com.fasterxml.jackson.databind.ObjectMapper} bean). */
 @Configuration
 public class TrainerConfig {
 

--- a/ai-sentinel-trainer/src/main/java/io/aisentinel/trainer/TrainerKafkaListener.java
+++ b/ai-sentinel-trainer/src/main/java/io/aisentinel/trainer/TrainerKafkaListener.java
@@ -4,6 +4,10 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
 
+/**
+ * Kafka consumer for training-candidate JSON; delegates to {@link TrainerOrchestrator}. Registered only when
+ * {@code aisentinel.trainer.kafka.enabled=true}.
+ */
 @Component
 @ConditionalOnProperty(name = "aisentinel.trainer.kafka.enabled", havingValue = "true")
 public class TrainerKafkaListener {

--- a/ai-sentinel-trainer/src/main/java/io/aisentinel/trainer/TrainerMetrics.java
+++ b/ai-sentinel-trainer/src/main/java/io/aisentinel/trainer/TrainerMetrics.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Component;
 
 import java.util.concurrent.TimeUnit;
 
+/** Micrometer counters and timers for {@code aisentinel.trainer.*} meters. */
 @Component
 public class TrainerMetrics {
 

--- a/ai-sentinel-trainer/src/main/java/io/aisentinel/trainer/TrainerOrchestrator.java
+++ b/ai-sentinel-trainer/src/main/java/io/aisentinel/trainer/TrainerOrchestrator.java
@@ -13,6 +13,10 @@ import org.springframework.stereotype.Service;
 import java.nio.file.Path;
 import java.util.List;
 
+/**
+ * Consumes JSON training candidates, maintains a bounded FIFO buffer, runs scheduled train cycles, publishes
+ * artifacts to the configured filesystem registry. Not on the API request path.
+ */
 @Service
 @Slf4j
 public class TrainerOrchestrator {

--- a/ai-sentinel-trainer/src/main/java/io/aisentinel/trainer/TrainerProperties.java
+++ b/ai-sentinel-trainer/src/main/java/io/aisentinel/trainer/TrainerProperties.java
@@ -4,6 +4,9 @@ import lombok.Data;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 
+/**
+ * Binds {@code aisentinel.trainer.*} (tenant, buffer, train schedule, IF hyperparameters, admission, dedup, Kafka).
+ */
 @Component
 @Data
 @ConfigurationProperties(prefix = "aisentinel.trainer")

--- a/ai-sentinel-trainer/src/main/java/io/aisentinel/trainer/package-info.java
+++ b/ai-sentinel-trainer/src/main/java/io/aisentinel/trainer/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Standalone trainer application: optional Kafka ingestion, bounded buffer, IF training, filesystem registry publisher.
+ * Separate deployable from {@code ai-sentinel-spring-boot-starter}; shares {@code ai-sentinel-core} only.
+ */
+package io.aisentinel.trainer;

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,69 @@
+# Configuration reference
+
+Properties use Spring Boot relaxed binding (`ai.sentinel.*`, `aisentinel.trainer.*`). See **`SentinelProperties`** and **`TrainerProperties`** in the codebase for validation rules.
+
+---
+
+## Core (`ai.sentinel.*`)
+
+| Property | Default | Notes |
+|----------|---------|--------|
+| `ai.sentinel.enabled` | `true` | Master switch |
+| `ai.sentinel.mode` | `ENFORCE` | `OFF`, `MONITOR`, `ENFORCE` |
+| `ai.sentinel.exclude-paths` | actuator, health, static, favicon | Comma-separated Ant-style patterns |
+| `ai.sentinel.trusted-proxies` | _(empty)_ | IPs or CIDRs; when remote matches, client IP from forwarded headers (see [`ARCHITECTURE.md`](../ARCHITECTURE.md) §8) |
+| `ai.sentinel.threshold-moderate` … `threshold-critical` | `0.2` … `0.8` | Strictly increasing, in `[0,1]` |
+| `ai.sentinel.warmup-min-samples` / `warmup-score` | `2` / `0.4` | Cold-start statistical behavior |
+| `ai.sentinel.startup-grace-period` | `0` | Duration (e.g. `5m`) enforcing monitor-only after startup |
+| `ai.sentinel.enforcement-scope` | `IDENTITY_ENDPOINT` | Throttle/quarantine key scope |
+| `ai.sentinel.isolation-forest.enabled` | `false` | In-core Isolation Forest |
+| `ai.sentinel.telemetry.log-verbosity` | `ANOMALY_ONLY` | `FULL`, `ANOMALY_ONLY`, `SAMPLED`, `NONE` |
+| `ai.sentinel.distributed.cluster-quarantine-read-enabled` | `false` | Merge cluster quarantine into `isQuarantined` (local OR Redis view) |
+| `ai.sentinel.distributed.cluster-quarantine-write-enabled` | `false` | After local `QUARANTINE`, publish `until` to Redis (requires `distributed.enabled`, `redis.enabled`, template; async, fail-open) |
+| `ai.sentinel.distributed.cluster-throttle-enabled` | `false` | On the **THROTTLE** action path only, consult a Redis fixed-window counter per enforcement key (cluster-wide cap; fail-open if Redis fails; requires `distributed.enabled`, `redis.enabled`, template) |
+| `ai.sentinel.distributed.cluster-throttle-window` | `1s` | Wall-clock window length for the cluster throttle counter (validated ≥ 100ms) |
+| `ai.sentinel.distributed.cluster-throttle-max-requests-per-window` | `30` | Max requests cluster-wide per enforcement key per window when cluster throttle is enabled (validated ≥ 1) |
+| `ai.sentinel.distributed.cluster-throttle-max-in-flight` | `1024` | Per-JVM semaphore cap for concurrent cluster-throttle Redis evals; extra evaluations fail-open (metric `aisentinel.distributed.throttle.executor.rejected`); runtime clamp `[1, 50000]` |
+| `ai.sentinel.distributed.cluster-throttle-timeout` | _(unset)_ | Max wait on the throttle Redis future; when unset or non-positive, uses `distributed.redis.lookup-timeout` |
+| `ai.sentinel.distributed.training-publish-enabled` | `false` | Phase 5.5: async export of versioned training candidates after enforcement (fail-open; bounded) |
+| `ai.sentinel.distributed.training-publish-sample-rate` | `0.1` | Uniform fraction for the probabilistic sample gate (0–1); high composite scores can bypass when stratified sampling is on |
+| `ai.sentinel.distributed.training-publish-stratified-sampling` | `true` | When true, composite ≥ `training-publish-high-composite-bypass-sample-min-score` skips the uniform sample draw |
+| `ai.sentinel.distributed.training-publish-high-composite-bypass-sample-min-score` | `0.4` | Inclusive floor for bypassing uniform sampling when stratified sampling is enabled (0–1) |
+| `ai.sentinel.distributed.training-publish-max-in-flight` | `256` | Semaphore cap for concurrent publish tasks; excess dropped with metric |
+| `ai.sentinel.distributed.training-publish-timeout` | `2s` | Max wait on Kafka send completion (`future.get`); validated ≤ 30s; transport clamps to 10s |
+| `ai.sentinel.distributed.training-publish-min-composite-score` | `0` | Minimum composite score to export (inclusive) |
+| `ai.sentinel.distributed.training-publish-apply-if-anti-poisoning` | `true` | Skip export when IF score &gt; `isolation-forest.training-rejection-score-threshold` (when IF score present) |
+| `ai.sentinel.distributed.training-publisher-node-id` | _(empty)_ | Optional instance id in exported events (max length 128) |
+| `ai.sentinel.distributed.training-kafka-enabled` | `false` | Use `KafkaTemplate` when present (requires `spring-kafka` + broker config); else JSON log line transport |
+| `ai.sentinel.distributed.training-candidates-topic` | `aisentinel.training.candidates` | Kafka topic when Kafka transport is active |
+| `ai.sentinel.distributed.enabled` | `false` | Master switch for Redis-backed distributed features |
+| `ai.sentinel.distributed.redis.enabled` | `false` | Enables Redis-backed beans when `spring-boot-starter-data-redis` and a `StringRedisTemplate` are present |
+| `ai.sentinel.distributed.redis.key-prefix` | `aisentinel` | Key prefix for quarantine keys `{prefix}:{tenant}:q:{enforcementKey}` and throttle keys `{prefix}:{tenant}:th:{bucket}:{enforcementKey}` |
+| `ai.sentinel.distributed.redis.lookup-timeout` | `50ms` | Max wait on async Redis futures for **cluster quarantine GET** and (when `cluster-throttle-timeout` is unset) **cluster throttle** Lua eval; prefer **Lettuce** and align `spring.data.redis.timeout` with these budgets |
+| `ai.sentinel.distributed.redis.max-in-flight-quarantine-writes` | `256` | Semaphore cap for concurrent async cluster quarantine SETs; extra publishes are dropped (metric) without blocking the caller |
+| `ai.sentinel.distributed.cache.enabled` | `true` | When `false`, skip the local cache (every lookup hits Redis within `lookup-timeout`) |
+| `ai.sentinel.distributed.cache.ttl` / `cache.max-entries` | `2s` / `10000` | Local bounded cache for Redis quarantine lookups |
+| `ai.sentinel.distributed.cache.negative-ttl` | _(unset)_ | TTL for negative (miss) cache lines; if unset, derived as `max(100ms, min(positiveTtl/2, 2s))` |
+| `ai.sentinel.model-registry.refresh-enabled` | `false` | Phase 5.6: background poll filesystem registry for newer IF artifacts (requires IF enabled + non-blank `filesystem-root`) |
+| `ai.sentinel.model-registry.filesystem-root` | _(empty)_ | Registry root shared with `ai-sentinel-trainer` output (`{root}/{tenant}/active.json` + `artifacts/`) |
+| `ai.sentinel.model-registry.poll-interval` | `5m` | Poll interval (validated 10s–24h) |
+
+### Redis and request-path budget
+
+Add `spring-boot-starter-data-redis` and `spring.data.redis.*` when using cluster quarantine read/write and/or cluster throttle. Quarantine write propagation runs **asynchronously** after local quarantine is applied; Redis failures do not roll back local quarantine. Cluster throttle uses a short-budget async Redis **INCR** + **EXPIRE** script; on timeout or error the check **allows** the request (fail-open) and local per-node throttling still applies afterward. The **filter thread** waits up to the configured throttle/quarantine timeout for the Redis future, so **Redis round-trip latency is part of the request-path budget** for that check.
+
+### Isolation Forest (demo)
+
+Use the bundled **`stage2`** profile for faster local training:
+
+```bash
+mvn -pl ai-sentinel-demo spring-boot:run -Dspring-boot.run.profiles=stage2
+```
+
+Config: `ai-sentinel-demo/src/main/resources/application-stage2.yaml`.
+
+---
+
+## Trainer (`aisentinel.trainer.*`)
+
+See [`ai-sentinel-trainer/README.md`](../ai-sentinel-trainer/README.md) for the full table and run instructions.


### PR DESCRIPTION
This PR lands documentation and contributor workflow updates (including the **`main` / `dev`** branching model) alongside follow-on **trainer**, **model registry refresh**, and **core/starter** integration work.
## Documentation
- Add **`CONTRIBUTING.md`** with branching strategy, PR expectations, and contributor conventions.
- Add **`SECURITY.md`** with supported-version / fix-flow language aligned with **`dev` → release → `main`** (and rare **`main`** hotfixes merged back to **`dev`**).
- Refresh root **`README.md`** (structure, quickstart, contributing pointer) and **`ARCHITECTURE.md`** for current behavior.
- Add **`docs/configuration.md`** and short module **`README.md`** files where helpful.
- Add **`package-info.java`** stubs for documented packages.
## Code / integration
- Trainer and training-path wiring (orchestration, Kafka listener, metrics, properties, config).
- Model registry reader / refresh scheduling and related starter auto-configuration.
- Core pipeline, telemetry, scoring, policy, enforcement, and distributed training publisher touchpoints as in the diff.
- Small **`.gitignore`** adjustment for tracked docs.
## How to review
- Skim **`CONTRIBUTING.md`** / **`SECURITY.md`** for workflow accuracy.
- Spot-check **`README.md`** and **`ARCHITECTURE.md`** against the current modules and Phase 5.5/5.6 story.
- For code, focus on trainer + registry refresh + starter filter/actuator paths.
