### PR TITLE
ci: trim duplicate runs, tighten permissions, and improve test artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,14 +8,18 @@ on:
     types: [opened, synchronize, reopened]
     branches: [main, dev]
   push:
-    branches: [main, dev]
+    branches: [main]
 
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   build:
+    name: Build & test (JDK 21)
     runs-on: ubuntu-latest
     timeout-minutes: 30
 
@@ -31,12 +35,14 @@ jobs:
           cache: maven
 
       - name: Build and test (reactor)
-        run: mvn -B verify
+        run: mvn -B -ntp verify
 
-      - name: Upload Surefire reports (on failure)
+      - name: Upload test reports (on failure)
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: surefire-reports
-          path: "**/target/surefire-reports/**"
+          name: test-reports
+          path: |
+            **/target/surefire-reports/**
+            **/target/failsafe-reports/**
           if-no-files-found: ignore


### PR DESCRIPTION
Small **CI stabilization** pass for the existing GitHub Actions workflow: fewer redundant runs, least-privilege permissions, slightly quieter Maven output, clearer job naming, and broader failure artifacts.
## Changes
- **Triggers:** `push` only on **`main`** (keeps post-merge checks). **`pull_request`** unchanged for bases **`main`** and **`dev`**, so pushes to **`dev`** no longer double-fire with PR `synchronize`.
- **Permissions:** `permissions: contents: read` at workflow level.
- **Maven:** `mvn -B -ntp verify` (batch + no transfer progress).
- **Artifacts (on failure):** upload **`test-reports`** including both `**/target/surefire-reports/**` and `**/target/failsafe-reports/**` (`if-no-files-found: ignore`).
- **Job UI:** display name **Build & test (JDK 21)** (job id remains `build`).
