### PR TITLE
test: fix flaky DistributedQuarantineValidationTest metric-delta race

### DIFF
--- a/ai-sentinel-spring-boot-starter/src/test/java/io/aisentinel/validation/DistributedQuarantineValidationTest.java
+++ b/ai-sentinel-spring-boot-starter/src/test/java/io/aisentinel/validation/DistributedQuarantineValidationTest.java
@@ -20,7 +20,10 @@ import io.aisentinel.distributed.quarantine.ClusterQuarantineWriter;
 import io.aisentinel.distributed.quarantine.NoopClusterQuarantineWriter;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -61,6 +64,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  * {@link ClusterAwareEnforcementHandler} and {@link SentinelFilter} (see enforcement test). Requires Docker for
  * Testcontainers; tests are skipped when Docker is unavailable.
  */
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 @Testcontainers(disabledWithoutDocker = true)
 @SpringBootTest(
     classes = DistributedValidationTestApplication.class,
@@ -137,6 +141,7 @@ class DistributedQuarantineValidationTest {
     private StartupGrace startupGrace;
 
     @Test
+    @Order(4)
     void nodeAQuarantineWritesRedis_nodeBReaderSeesClusterQuarantine_separateRedisClient_metricDeltas() throws Exception {
         MetricSnapshot before = MetricSnapshot.capture(micrometerSentinelMetrics, distributedQuarantineStatus);
 
@@ -177,6 +182,7 @@ class DistributedQuarantineValidationTest {
     }
 
     @Test
+    @Order(5)
     void nodeAWritesQuarantine_nodeBClusterAwareFilterBlocksHttp() throws Exception {
         MetricSnapshot before = MetricSnapshot.capture(micrometerSentinelMetrics, distributedQuarantineStatus);
 
@@ -196,11 +202,9 @@ class DistributedQuarantineValidationTest {
         assertThat(compositeEnforcementHandler.isQuarantined(identityHash, ENFORCEMENT_ENDPOINT)).isTrue();
 
         awaitKeyPresent(stringRedisTemplate, redisKey, 5_000);
-
-        MetricSnapshot mid = MetricSnapshot.capture(micrometerSentinelMetrics, distributedQuarantineStatus);
-        assertThat(mid.writeAttempts - before.writeAttempts).isGreaterThan(0);
-        assertThat(mid.writeSuccesses - before.writeSuccesses).isGreaterThan(0);
-        assertThat(mid.redisWriterDegraded).isFalse();
+        // Async Redis SET runs on a virtual thread; Micrometer success is recorded there. On slow CI, polling
+        // avoids racing the main thread snapshot before counters reflect the completed write.
+        awaitClusterWriteMetricsIncremented(before, 5_000);
 
         try (NodeBRedis nodeB = NodeBRedis.connect(REDIS)) {
             var readerStatusB = new DistributedQuarantineStatus();
@@ -250,6 +254,7 @@ class DistributedQuarantineValidationTest {
     }
 
     @Test
+    @Order(2)
     void actuatorExposesDistributedFlagsAndMetricSummary() {
         assertThat(sentinelActuatorEndpoint).isNotNull();
         Map<String, Object> info = sentinelActuatorEndpoint.info();
@@ -278,6 +283,7 @@ class DistributedQuarantineValidationTest {
     }
 
     @Test
+    @Order(3)
     void cacheServesStalePositiveUntilRedisKeyDeletedThenExpiresAndFailsOpen() throws Exception {
         String tenant = sentinelProperties.getDistributed().getTenantId();
         String enforcementKey = "cache-stale|/z";
@@ -311,6 +317,7 @@ class DistributedQuarantineValidationTest {
     }
 
     @Test
+    @Order(1)
     void writerBeanIsRedisImplementationInSharedRedisContext() {
         assertThat(clusterQuarantineWriter).isInstanceOf(
             io.aisentinel.autoconfigure.distributed.quarantine.RedisClusterQuarantineWriter.class);
@@ -342,6 +349,22 @@ class DistributedQuarantineValidationTest {
             Thread.sleep(25);
         }
         throw new AssertionError("Redis key not found within timeout: " + redisKey);
+    }
+
+    private void awaitClusterWriteMetricsIncremented(MetricSnapshot before, long timeoutMs) throws InterruptedException {
+        long deadline = System.currentTimeMillis() + timeoutMs;
+        while (System.currentTimeMillis() < deadline) {
+            MetricSnapshot now = MetricSnapshot.capture(micrometerSentinelMetrics, distributedQuarantineStatus);
+            if (now.writeAttempts > before.writeAttempts && now.writeSuccesses > before.writeSuccesses) {
+                assertThat(now.redisWriterDegraded).isFalse();
+                return;
+            }
+            Thread.sleep(20);
+        }
+        MetricSnapshot stuck = MetricSnapshot.capture(micrometerSentinelMetrics, distributedQuarantineStatus);
+        throw new AssertionError("Cluster quarantine write metrics did not increment within timeout: attempts "
+            + before.writeAttempts + " -> " + stuck.writeAttempts + ", successes " + before.writeSuccesses + " -> "
+            + stuck.writeSuccesses);
     }
 
     private record MetricSnapshot(


### PR DESCRIPTION
The cluster quarantine write path runs Redis SET on a virtual thread and publishes Micrometer counters after the SET returns. awaitKeyPresent proves the Redis side is durable but does not guarantee the counter increment is visible to the main thread. On slow CI runners this produced intermittent failures where writeAttempts/writeSuccesses deltas were still zero at the moment of assertion.

Replace the direct assertion with awaitClusterWriteMetricsIncremented, which polls with a 5s deadline and 20ms interval until both counters reflect the completed write. Failure message reports the delta progression for diagnostics.

Also enforce deterministic test ordering via @TestMethodOrder so baseline MetricSnapshots are predictable across runners.