### PR TITLE
Phase 0: identity foundation (core models, SPI, starter wiring, tests)

### DIFF
--- a/ai-sentinel-core/src/main/java/io/aisentinel/core/SentinelPipeline.java
+++ b/ai-sentinel-core/src/main/java/io/aisentinel/core/SentinelPipeline.java
@@ -4,6 +4,15 @@ import io.aisentinel.core.enforcement.EnforcementHandler;
 import io.aisentinel.core.enforcement.EnforcementKeys;
 import io.aisentinel.core.enforcement.EnforcementScope;
 import io.aisentinel.core.feature.FeatureExtractor;
+import io.aisentinel.core.identity.IdentityContextKeys;
+import io.aisentinel.core.identity.model.IdentityContext;
+import io.aisentinel.core.identity.model.TrustScore;
+import io.aisentinel.core.identity.spi.IdentityContextResolver;
+import io.aisentinel.core.identity.spi.IdentityResponseHook;
+import io.aisentinel.core.identity.spi.NoopIdentityContextResolver;
+import io.aisentinel.core.identity.spi.NoopIdentityResponseHook;
+import io.aisentinel.core.identity.spi.NoopTrustEvaluator;
+import io.aisentinel.core.identity.spi.TrustEvaluator;
 import io.aisentinel.core.model.RequestContext;
 import io.aisentinel.core.model.RequestFeatures;
 import io.aisentinel.core.policy.EnforcementAction;
@@ -44,12 +53,16 @@ public final class SentinelPipeline {
     private final String trainingTenantId;
     private final String trainingNodeId;
     private final String sentinelModeName;
+    private final IdentityContextResolver identityContextResolver;
+    private final TrustEvaluator trustEvaluator;
+    private final IdentityResponseHook identityResponseHook;
 
     public SentinelPipeline(FeatureExtractor featureExtractor, AnomalyScorer scorer, PolicyEngine policyEngine,
                             EnforcementHandler enforcementHandler, TelemetryEmitter telemetry, StartupGrace startupGrace,
                             SentinelMetrics metrics) {
         this(featureExtractor, scorer, null, policyEngine, enforcementHandler, telemetry, startupGrace, metrics,
-            NoopTrainingCandidatePublisher.INSTANCE, EnforcementScope.IDENTITY_ENDPOINT, "default", "", "ENFORCE");
+            NoopTrainingCandidatePublisher.INSTANCE, EnforcementScope.IDENTITY_ENDPOINT, "default", "", "ENFORCE",
+            NoopIdentityContextResolver.INSTANCE, NoopTrustEvaluator.INSTANCE, NoopIdentityResponseHook.INSTANCE);
     }
 
     public SentinelPipeline(FeatureExtractor featureExtractor,
@@ -64,7 +77,10 @@ public final class SentinelPipeline {
                             EnforcementScope enforcementScope,
                             String trainingTenantId,
                             String trainingNodeId,
-                            String sentinelModeName) {
+                            String sentinelModeName,
+                            IdentityContextResolver identityContextResolver,
+                            TrustEvaluator trustEvaluator,
+                            IdentityResponseHook identityResponseHook) {
         this.featureExtractor = featureExtractor;
         this.scorer = scorer;
         this.compositeScorerOrNull = compositeScorerOrNull;
@@ -80,6 +96,9 @@ public final class SentinelPipeline {
         this.trainingTenantId = trainingTenantId != null && !trainingTenantId.isBlank() ? trainingTenantId : "default";
         this.trainingNodeId = trainingNodeId != null ? trainingNodeId : "";
         this.sentinelModeName = sentinelModeName != null ? sentinelModeName : "ENFORCE";
+        this.identityContextResolver = identityContextResolver != null ? identityContextResolver : NoopIdentityContextResolver.INSTANCE;
+        this.trustEvaluator = trustEvaluator != null ? trustEvaluator : NoopTrustEvaluator.INSTANCE;
+        this.identityResponseHook = identityResponseHook != null ? identityResponseHook : NoopIdentityResponseHook.INSTANCE;
     }
 
     /**
@@ -87,15 +106,40 @@ public final class SentinelPipeline {
      */
     public boolean process(HttpServletRequest request, HttpServletResponse response, String identityHash) {
         long pipelineStart = System.nanoTime();
+        RequestContext ctx = new RequestContext();
+        RequestFeatures features = null;
+        boolean hookEligible = false;
+        boolean returnValue = true;
         try {
-            RequestContext ctx = new RequestContext();
-            RequestFeatures features;
+            try {
+                identityContextResolver.resolve(request, identityHash, ctx);
+            } catch (Exception e) {
+                log.debug("Identity resolution failed for {}: {}", request.getRequestURI(), e.getMessage());
+                metrics.recordFailOpen();
+            }
+
             try {
                 features = featureExtractor.extract(request, identityHash, ctx);
             } catch (Exception e) {
                 log.debug("Feature extraction failed for {}: {}", request.getRequestURI(), e.getMessage());
                 metrics.recordFailOpen();
-                return true;
+                returnValue = true;
+                return returnValue;
+            }
+
+            hookEligible = true;
+
+            IdentityContext identityCtx = ctx.get(IdentityContextKeys.IDENTITY_CONTEXT, IdentityContext.class);
+            if (identityCtx != null) {
+                try {
+                    TrustScore trust = trustEvaluator.evaluate(identityCtx, request, features, ctx);
+                    if (trust != null) {
+                        ctx.put(IdentityContextKeys.IDENTITY_CONTEXT, identityCtx.withTrust(trust));
+                    }
+                } catch (Exception e) {
+                    log.debug("Trust evaluation failed for {}: {}", features.endpoint(), e.getMessage());
+                    metrics.recordFailOpen();
+                }
             }
 
             double rawScore;
@@ -107,7 +151,8 @@ public final class SentinelPipeline {
                 log.debug("Scoring failed for {}: {}", features.endpoint(), e.getMessage());
                 metrics.recordScoringError();
                 metrics.recordFailOpen();
-                return true;
+                returnValue = true;
+                return returnValue;
             } finally {
                 metrics.recordScoringLatencyNanos(System.nanoTime() - scoreStart);
             }
@@ -136,9 +181,17 @@ public final class SentinelPipeline {
 
             offerTrainingCandidate(features, identityHash, action, score, proceed, startupGraceActive);
 
-            return proceed;
+            returnValue = proceed;
+            return returnValue;
         } finally {
             metrics.recordPipelineLatencyNanos(System.nanoTime() - pipelineStart);
+            if (hookEligible) {
+                try {
+                    identityResponseHook.afterPipeline(request, response, identityHash, features, ctx, returnValue);
+                } catch (Exception e) {
+                    log.debug("Identity response hook failed: {}", e.getMessage());
+                }
+            }
         }
     }
 

--- a/ai-sentinel-core/src/main/java/io/aisentinel/core/identity/IdentityContextKeys.java
+++ b/ai-sentinel-core/src/main/java/io/aisentinel/core/identity/IdentityContextKeys.java
@@ -1,0 +1,12 @@
+package io.aisentinel.core.identity;
+
+/**
+ * Keys for storing identity-related values in {@link io.aisentinel.core.model.RequestContext}.
+ */
+public final class IdentityContextKeys {
+
+    /** {@link io.aisentinel.core.identity.model.IdentityContext} when the identity module populates it. */
+    public static final String IDENTITY_CONTEXT = "io.aisentinel.identity.context";
+
+    private IdentityContextKeys() {}
+}

--- a/ai-sentinel-core/src/main/java/io/aisentinel/core/identity/model/AuthenticationContext.java
+++ b/ai-sentinel-core/src/main/java/io/aisentinel/core/identity/model/AuthenticationContext.java
@@ -1,0 +1,25 @@
+package io.aisentinel.core.identity.model;
+
+import java.util.Objects;
+
+/**
+ * Snapshot of authentication state for the current request (no raw credentials).
+ */
+public record AuthenticationContext(
+    boolean authenticated,
+    boolean anonymous,
+    String principalName
+) {
+    public AuthenticationContext {
+        principalName = principalName != null ? principalName : "";
+    }
+
+    public static AuthenticationContext unauthenticated() {
+        return new AuthenticationContext(false, true, "");
+    }
+
+    public static AuthenticationContext ofPrincipal(String name) {
+        Objects.requireNonNull(name, "name");
+        return new AuthenticationContext(true, false, name);
+    }
+}

--- a/ai-sentinel-core/src/main/java/io/aisentinel/core/identity/model/IdentityContext.java
+++ b/ai-sentinel-core/src/main/java/io/aisentinel/core/identity/model/IdentityContext.java
@@ -1,0 +1,22 @@
+package io.aisentinel.core.identity.model;
+
+/**
+ * Identity-centric view for a single request, carried in {@link io.aisentinel.core.model.RequestContext}.
+ */
+public record IdentityContext(
+    AuthenticationContext authentication,
+    SessionContext session,
+    TrustScore trust,
+    IdentityRiskSignals riskSignals
+) {
+    public IdentityContext {
+        authentication = authentication != null ? authentication : AuthenticationContext.unauthenticated();
+        session = session != null ? session : SessionContext.none();
+        trust = trust != null ? trust : TrustScore.fullyTrusted();
+        riskSignals = riskSignals != null ? riskSignals : IdentityRiskSignals.empty();
+    }
+
+    public IdentityContext withTrust(TrustScore newTrust) {
+        return new IdentityContext(authentication, session, newTrust, riskSignals);
+    }
+}

--- a/ai-sentinel-core/src/main/java/io/aisentinel/core/identity/model/IdentityRiskSignals.java
+++ b/ai-sentinel-core/src/main/java/io/aisentinel/core/identity/model/IdentityRiskSignals.java
@@ -1,0 +1,16 @@
+package io.aisentinel.core.identity.model;
+
+import java.util.Map;
+
+/**
+ * Placeholder for future identity-side risk factors (fed into the shared threat engine in later phases).
+ */
+public record IdentityRiskSignals(Map<String, Double> components) {
+    public IdentityRiskSignals {
+        components = components != null ? Map.copyOf(components) : Map.of();
+    }
+
+    public static IdentityRiskSignals empty() {
+        return new IdentityRiskSignals(Map.of());
+    }
+}

--- a/ai-sentinel-core/src/main/java/io/aisentinel/core/identity/model/SessionContext.java
+++ b/ai-sentinel-core/src/main/java/io/aisentinel/core/identity/model/SessionContext.java
@@ -1,0 +1,21 @@
+package io.aisentinel.core.identity.model;
+
+/**
+ * Opaque session reference for the current request (hashed identifiers only).
+ */
+public record SessionContext(
+    boolean present,
+    String sessionIdHash
+) {
+    public SessionContext {
+        sessionIdHash = sessionIdHash != null ? sessionIdHash : "";
+    }
+
+    public static SessionContext none() {
+        return new SessionContext(false, "");
+    }
+
+    public static SessionContext ofHashedId(String sessionIdHash) {
+        return new SessionContext(sessionIdHash != null && !sessionIdHash.isEmpty(), sessionIdHash != null ? sessionIdHash : "");
+    }
+}

--- a/ai-sentinel-core/src/main/java/io/aisentinel/core/identity/model/TrustScore.java
+++ b/ai-sentinel-core/src/main/java/io/aisentinel/core/identity/model/TrustScore.java
@@ -1,0 +1,20 @@
+package io.aisentinel.core.identity.model;
+
+/**
+ * Session / identity trust level in {@code [0.0, 1.0]} where higher means more trusted.
+ * Distinct from API anomaly risk scores; used by the Identity arm for future adaptive decisions.
+ */
+public record TrustScore(double value, String reason) {
+    public TrustScore {
+        if (Double.isNaN(value)) {
+            value = 0.0;
+        }
+        value = Math.max(0.0, Math.min(1.0, value));
+        reason = reason != null ? reason : "";
+    }
+
+    /** Baseline for Phase 0: no behavioral trust degradation applied. */
+    public static TrustScore fullyTrusted() {
+        return new TrustScore(1.0, "baseline");
+    }
+}

--- a/ai-sentinel-core/src/main/java/io/aisentinel/core/identity/spi/AuthenticationInspector.java
+++ b/ai-sentinel-core/src/main/java/io/aisentinel/core/identity/spi/AuthenticationInspector.java
@@ -1,0 +1,13 @@
+package io.aisentinel.core.identity.spi;
+
+import io.aisentinel.core.identity.model.AuthenticationContext;
+import jakarta.servlet.http.HttpServletRequest;
+
+/**
+ * Inspects servlet-layer authentication for {@link IdentityContext} assembly.
+ */
+@FunctionalInterface
+public interface AuthenticationInspector {
+
+    AuthenticationContext inspect(HttpServletRequest request, String identityHash);
+}

--- a/ai-sentinel-core/src/main/java/io/aisentinel/core/identity/spi/IdentityContextResolver.java
+++ b/ai-sentinel-core/src/main/java/io/aisentinel/core/identity/spi/IdentityContextResolver.java
@@ -1,0 +1,12 @@
+package io.aisentinel.core.identity.spi;
+
+import io.aisentinel.core.model.RequestContext;
+import jakarta.servlet.http.HttpServletRequest;
+
+/**
+ * Populates identity-related state on the shared {@link RequestContext} before feature extraction.
+ */
+public interface IdentityContextResolver {
+
+    void resolve(HttpServletRequest request, String identityHash, RequestContext ctx);
+}

--- a/ai-sentinel-core/src/main/java/io/aisentinel/core/identity/spi/IdentityResponseHook.java
+++ b/ai-sentinel-core/src/main/java/io/aisentinel/core/identity/spi/IdentityResponseHook.java
@@ -1,0 +1,15 @@
+package io.aisentinel.core.identity.spi;
+
+import io.aisentinel.core.model.RequestContext;
+import io.aisentinel.core.model.RequestFeatures;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+/**
+ * Optional callback after the pipeline completes (success or early failure after feature extraction).
+ */
+public interface IdentityResponseHook {
+
+    void afterPipeline(HttpServletRequest request, HttpServletResponse response, String identityHash,
+                       RequestFeatures features, RequestContext ctx, boolean requestProceeded);
+}

--- a/ai-sentinel-core/src/main/java/io/aisentinel/core/identity/spi/NoopIdentityContextResolver.java
+++ b/ai-sentinel-core/src/main/java/io/aisentinel/core/identity/spi/NoopIdentityContextResolver.java
@@ -1,0 +1,16 @@
+package io.aisentinel.core.identity.spi;
+
+import io.aisentinel.core.model.RequestContext;
+import jakarta.servlet.http.HttpServletRequest;
+
+/**
+ * Default when {@code ai.sentinel.identity.enabled=false}: leaves {@link RequestContext} unchanged.
+ */
+public enum NoopIdentityContextResolver implements IdentityContextResolver {
+    INSTANCE;
+
+    @Override
+    public void resolve(HttpServletRequest request, String identityHash, RequestContext ctx) {
+        // intentionally empty
+    }
+}

--- a/ai-sentinel-core/src/main/java/io/aisentinel/core/identity/spi/NoopIdentityResponseHook.java
+++ b/ai-sentinel-core/src/main/java/io/aisentinel/core/identity/spi/NoopIdentityResponseHook.java
@@ -1,0 +1,16 @@
+package io.aisentinel.core.identity.spi;
+
+import io.aisentinel.core.model.RequestContext;
+import io.aisentinel.core.model.RequestFeatures;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+public enum NoopIdentityResponseHook implements IdentityResponseHook {
+    INSTANCE;
+
+    @Override
+    public void afterPipeline(HttpServletRequest request, HttpServletResponse response, String identityHash,
+                              RequestFeatures features, RequestContext ctx, boolean requestProceeded) {
+        // intentionally empty
+    }
+}

--- a/ai-sentinel-core/src/main/java/io/aisentinel/core/identity/spi/NoopTrustEvaluator.java
+++ b/ai-sentinel-core/src/main/java/io/aisentinel/core/identity/spi/NoopTrustEvaluator.java
@@ -1,0 +1,20 @@
+package io.aisentinel.core.identity.spi;
+
+import io.aisentinel.core.identity.model.IdentityContext;
+import io.aisentinel.core.identity.model.TrustScore;
+import io.aisentinel.core.model.RequestContext;
+import io.aisentinel.core.model.RequestFeatures;
+import jakarta.servlet.http.HttpServletRequest;
+
+/**
+ * Default when identity is disabled: does not adjust trust.
+ */
+public enum NoopTrustEvaluator implements TrustEvaluator {
+    INSTANCE;
+
+    @Override
+    public TrustScore evaluate(IdentityContext identity, HttpServletRequest request, RequestFeatures features,
+                               RequestContext ctx) {
+        return null;
+    }
+}

--- a/ai-sentinel-core/src/main/java/io/aisentinel/core/identity/spi/SessionInspector.java
+++ b/ai-sentinel-core/src/main/java/io/aisentinel/core/identity/spi/SessionInspector.java
@@ -1,0 +1,13 @@
+package io.aisentinel.core.identity.spi;
+
+import io.aisentinel.core.identity.model.SessionContext;
+import jakarta.servlet.http.HttpServletRequest;
+
+/**
+ * Inspects servlet session metadata for {@link IdentityContext} assembly (hashed identifiers only).
+ */
+@FunctionalInterface
+public interface SessionInspector {
+
+    SessionContext inspect(HttpServletRequest request, String identityHash);
+}

--- a/ai-sentinel-core/src/main/java/io/aisentinel/core/identity/spi/TrustEvaluator.java
+++ b/ai-sentinel-core/src/main/java/io/aisentinel/core/identity/spi/TrustEvaluator.java
@@ -1,0 +1,21 @@
+package io.aisentinel.core.identity.spi;
+
+import io.aisentinel.core.identity.model.IdentityContext;
+import io.aisentinel.core.identity.model.TrustScore;
+import io.aisentinel.core.model.RequestContext;
+import io.aisentinel.core.model.RequestFeatures;
+import jakarta.servlet.http.HttpServletRequest;
+
+/**
+ * Hook for future continuous trust / session trust scoring. Must not alter API anomaly scores in Phase 0.
+ * <p>
+ * The default starter wiring uses {@link NoopTrustEvaluator}, which returns {@code null} so the
+ * {@link IdentityContext} trust set during resolution is left unchanged. Supply a custom bean when Phase 1+ needs
+ * trust updates without touching the anomaly {@link io.aisentinel.core.scoring.AnomalyScorer}.
+ *
+ * @return updated trust, or {@code null} to leave the current {@link IdentityContext} trust unchanged
+ */
+public interface TrustEvaluator {
+
+    TrustScore evaluate(IdentityContext identity, HttpServletRequest request, RequestFeatures features, RequestContext ctx);
+}

--- a/ai-sentinel-core/src/test/java/io/aisentinel/core/SentinelPipelineIdentityFailOpenTest.java
+++ b/ai-sentinel-core/src/test/java/io/aisentinel/core/SentinelPipelineIdentityFailOpenTest.java
@@ -1,0 +1,161 @@
+package io.aisentinel.core;
+
+import io.aisentinel.core.enforcement.EnforcementHandler;
+import io.aisentinel.core.enforcement.EnforcementScope;
+import io.aisentinel.core.feature.FeatureExtractor;
+import io.aisentinel.core.identity.IdentityContextKeys;
+import io.aisentinel.core.identity.model.AuthenticationContext;
+import io.aisentinel.core.identity.model.IdentityContext;
+import io.aisentinel.core.identity.model.IdentityRiskSignals;
+import io.aisentinel.core.identity.model.SessionContext;
+import io.aisentinel.core.identity.model.TrustScore;
+import io.aisentinel.core.identity.spi.IdentityContextResolver;
+import io.aisentinel.core.identity.spi.IdentityResponseHook;
+import io.aisentinel.core.identity.spi.NoopIdentityResponseHook;
+import io.aisentinel.core.identity.spi.NoopTrustEvaluator;
+import io.aisentinel.core.identity.spi.TrustEvaluator;
+import io.aisentinel.core.model.RequestContext;
+import io.aisentinel.core.model.RequestFeatures;
+import io.aisentinel.core.metrics.SentinelMetrics;
+import io.aisentinel.core.policy.EnforcementAction;
+import io.aisentinel.core.policy.PolicyEngine;
+import io.aisentinel.core.runtime.StartupGrace;
+import io.aisentinel.core.scoring.AnomalyScorer;
+import io.aisentinel.core.telemetry.TelemetryEmitter;
+import io.aisentinel.distributed.training.NoopTrainingCandidatePublisher;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyDouble;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class SentinelPipelineIdentityFailOpenTest {
+
+    private static RequestFeatures dummyFeatures() {
+        return RequestFeatures.builder()
+            .identityHash("h").endpoint("/api").timestampMillis(0)
+            .requestsPerWindow(1).endpointEntropy(0).tokenAgeSeconds(60)
+            .parameterCount(0).payloadSizeBytes(0).headerFingerprintHash(0).ipBucket(0).build();
+    }
+
+    @Test
+    void identityResolverThrowRecordsFailOpenAndRequestContinues() throws Exception {
+        AtomicInteger failOpen = new AtomicInteger();
+        SentinelMetrics metrics = new SentinelMetrics() {
+            @Override
+            public void recordFailOpen() {
+                failOpen.incrementAndGet();
+            }
+        };
+        FeatureExtractor extractor = mock(FeatureExtractor.class);
+        when(extractor.extract(any(), eq("h"), any(RequestContext.class)))
+            .thenReturn(dummyFeatures());
+        AnomalyScorer scorer = mock(AnomalyScorer.class);
+        when(scorer.score(any())).thenReturn(0.1);
+        PolicyEngine policy = mock(PolicyEngine.class);
+        when(policy.evaluate(anyDouble(), any(), eq("/api")))
+            .thenReturn(EnforcementAction.ALLOW);
+        EnforcementHandler handler = mock(EnforcementHandler.class);
+        when(handler.isQuarantined(anyString(), anyString())).thenReturn(false);
+        when(handler.apply(eq(EnforcementAction.ALLOW), any(), any(),
+            eq("h"), eq("/api"))).thenReturn(true);
+
+        IdentityContextResolver badResolver = (req, hash, ctx) -> {
+            throw new RuntimeException("identity boom");
+        };
+
+        SentinelPipeline pipeline = new SentinelPipeline(
+            extractor,
+            scorer,
+            null,
+            policy,
+            handler,
+            mock(TelemetryEmitter.class),
+            StartupGrace.NEVER,
+            metrics,
+            NoopTrainingCandidatePublisher.INSTANCE,
+            EnforcementScope.IDENTITY_ENDPOINT,
+            "default",
+            "",
+            "ENFORCE",
+            badResolver,
+            NoopTrustEvaluator.INSTANCE,
+            NoopIdentityResponseHook.INSTANCE
+        );
+
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        HttpServletResponse response = mock(HttpServletResponse.class);
+        assertThat(pipeline.process(request, response, "h")).isTrue();
+        assertThat(failOpen.get()).isEqualTo(1);
+        verify(handler).apply(eq(EnforcementAction.ALLOW), eq(request), eq(response), eq("h"), eq("/api"));
+    }
+
+    @Test
+    void trustEvaluatorThrowRecordsFailOpenAndRequestContinues() throws Exception {
+        AtomicInteger failOpen = new AtomicInteger();
+        SentinelMetrics metrics = new SentinelMetrics() {
+            @Override
+            public void recordFailOpen() {
+                failOpen.incrementAndGet();
+            }
+        };
+        IdentityContextResolver resolver = (req, hash, ctx) -> {
+            IdentityContext ic = new IdentityContext(
+                AuthenticationContext.unauthenticated(),
+                SessionContext.none(),
+                TrustScore.fullyTrusted(),
+                IdentityRiskSignals.empty());
+            ctx.put(IdentityContextKeys.IDENTITY_CONTEXT, ic);
+        };
+        TrustEvaluator badTrust = (id, req, f, ctx) -> {
+            throw new RuntimeException("trust boom");
+        };
+
+        FeatureExtractor extractor = mock(FeatureExtractor.class);
+        when(extractor.extract(any(), eq("h"), any(RequestContext.class)))
+            .thenReturn(dummyFeatures());
+        AnomalyScorer scorer = mock(AnomalyScorer.class);
+        when(scorer.score(any())).thenReturn(0.1);
+        PolicyEngine policy = mock(PolicyEngine.class);
+        when(policy.evaluate(anyDouble(), any(), eq("/api")))
+            .thenReturn(EnforcementAction.ALLOW);
+        EnforcementHandler handler = mock(EnforcementHandler.class);
+        when(handler.isQuarantined(anyString(), anyString())).thenReturn(false);
+        when(handler.apply(eq(EnforcementAction.ALLOW), any(), any(),
+            eq("h"), eq("/api"))).thenReturn(true);
+
+        SentinelPipeline pipeline = new SentinelPipeline(
+            extractor,
+            scorer,
+            null,
+            policy,
+            handler,
+            mock(TelemetryEmitter.class),
+            StartupGrace.NEVER,
+            metrics,
+            NoopTrainingCandidatePublisher.INSTANCE,
+            EnforcementScope.IDENTITY_ENDPOINT,
+            "default",
+            "",
+            "ENFORCE",
+            resolver,
+            badTrust,
+            NoopIdentityResponseHook.INSTANCE
+        );
+
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        HttpServletResponse response = mock(HttpServletResponse.class);
+        assertThat(pipeline.process(request, response, "h")).isTrue();
+        assertThat(failOpen.get()).isEqualTo(1);
+        verify(handler).apply(eq(EnforcementAction.ALLOW), eq(request), eq(response), eq("h"), eq("/api"));
+    }
+}

--- a/ai-sentinel-core/src/test/java/io/aisentinel/core/SentinelPipelineTrainingPublishTest.java
+++ b/ai-sentinel-core/src/test/java/io/aisentinel/core/SentinelPipelineTrainingPublishTest.java
@@ -10,6 +10,9 @@ import io.aisentinel.core.policy.EnforcementAction;
 import io.aisentinel.core.policy.PolicyEngine;
 import io.aisentinel.core.runtime.StartupGrace;
 import io.aisentinel.core.scoring.CompositeScorer;
+import io.aisentinel.core.identity.spi.NoopIdentityContextResolver;
+import io.aisentinel.core.identity.spi.NoopIdentityResponseHook;
+import io.aisentinel.core.identity.spi.NoopTrustEvaluator;
 import io.aisentinel.core.telemetry.TelemetryEmitter;
 import io.aisentinel.distributed.training.TrainingCandidatePublishRequest;
 import io.aisentinel.distributed.training.TrainingCandidatePublisher;
@@ -65,7 +68,10 @@ class SentinelPipelineTrainingPublishTest {
             EnforcementScope.IDENTITY_ENDPOINT,
             "tenant1",
             "node-a",
-            "ENFORCE"
+            "ENFORCE",
+            NoopIdentityContextResolver.INSTANCE,
+            NoopTrustEvaluator.INSTANCE,
+            NoopIdentityResponseHook.INSTANCE
         );
 
         HttpServletRequest request = mock(HttpServletRequest.class);

--- a/ai-sentinel-spring-boot-starter/pom.xml
+++ b/ai-sentinel-spring-boot-starter/pom.xml
@@ -70,6 +70,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>

--- a/ai-sentinel-spring-boot-starter/src/main/java/io/aisentinel/autoconfigure/config/SentinelAutoConfiguration.java
+++ b/ai-sentinel-spring-boot-starter/src/main/java/io/aisentinel/autoconfigure/config/SentinelAutoConfiguration.java
@@ -1,6 +1,12 @@
 package io.aisentinel.autoconfigure.config;
 
 import io.aisentinel.core.SentinelPipeline;
+import io.aisentinel.core.identity.spi.IdentityContextResolver;
+import io.aisentinel.core.identity.spi.IdentityResponseHook;
+import io.aisentinel.core.identity.spi.NoopIdentityContextResolver;
+import io.aisentinel.core.identity.spi.NoopIdentityResponseHook;
+import io.aisentinel.core.identity.spi.NoopTrustEvaluator;
+import io.aisentinel.core.identity.spi.TrustEvaluator;
 import io.aisentinel.autoconfigure.distributed.DistributedQuarantineStatus;
 import io.aisentinel.core.enforcement.CompositeEnforcementHandler;
 import io.aisentinel.core.enforcement.EnforcementHandler;
@@ -427,11 +433,26 @@ public class SentinelAutoConfiguration {
                                              StartupGrace sentinelStartupGrace,
                                              SentinelMetrics sentinelMetrics,
                                              TrainingCandidatePublisher trainingCandidatePublisher,
-                                             SentinelProperties props) {
+                                             SentinelProperties props,
+                                             ObjectProvider<IdentityContextResolver> identityContextResolverProvider,
+                                             ObjectProvider<TrustEvaluator> trustEvaluatorProvider,
+                                             ObjectProvider<IdentityResponseHook> identityResponseHookProvider) {
         log.info("Sentinel pipeline configured (mode={})", props.getMode());
         String nodeId = props.getDistributed().getTrainingPublisherNodeId();
         if (nodeId == null) {
             nodeId = "";
+        }
+        IdentityContextResolver identityContextResolver = identityContextResolverProvider.getIfAvailable();
+        if (identityContextResolver == null) {
+            identityContextResolver = NoopIdentityContextResolver.INSTANCE;
+        }
+        TrustEvaluator trustEvaluator = trustEvaluatorProvider.getIfAvailable();
+        if (trustEvaluator == null) {
+            trustEvaluator = NoopTrustEvaluator.INSTANCE;
+        }
+        IdentityResponseHook identityResponseHook = identityResponseHookProvider.getIfAvailable();
+        if (identityResponseHook == null) {
+            identityResponseHook = NoopIdentityResponseHook.INSTANCE;
         }
         return new SentinelPipeline(
             featureExtractor,
@@ -446,7 +467,10 @@ public class SentinelAutoConfiguration {
             props.getEnforcementScope(),
             props.getDistributed().getTenantId(),
             nodeId,
-            props.getMode().name()
+            props.getMode().name(),
+            identityContextResolver,
+            trustEvaluator,
+            identityResponseHook
         );
     }
 

--- a/ai-sentinel-spring-boot-starter/src/main/java/io/aisentinel/autoconfigure/config/SentinelProperties.java
+++ b/ai-sentinel-spring-boot-starter/src/main/java/io/aisentinel/autoconfigure/config/SentinelProperties.java
@@ -67,6 +67,18 @@ public class SentinelProperties {
     /** Phase 5.6 — optional filesystem model registry refresh on serving nodes (off-request). */
     @Valid
     private ModelRegistry modelRegistry = new ModelRegistry();
+    /** Identity arm foundation (Phase 0): disabled by default; no change to API security behavior when off. */
+    @Valid
+    private Identity identity = new Identity();
+
+    @Data
+    public static class Identity {
+        /**
+         * When false (default), identity SPI beans use no-op implementations and {@link io.aisentinel.core.model.RequestContext}
+         * is not populated with {@link io.aisentinel.core.identity.model.IdentityContext}.
+         */
+        private boolean enabled = false;
+    }
 
     @Data
     public static class ModelRegistry {

--- a/ai-sentinel-spring-boot-starter/src/main/java/io/aisentinel/autoconfigure/identity/HttpSessionSessionInspector.java
+++ b/ai-sentinel-spring-boot-starter/src/main/java/io/aisentinel/autoconfigure/identity/HttpSessionSessionInspector.java
@@ -1,0 +1,29 @@
+package io.aisentinel.autoconfigure.identity;
+
+import io.aisentinel.core.identity.model.SessionContext;
+import io.aisentinel.core.identity.spi.SessionInspector;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
+
+/**
+ * Exposes a hashed servlet session id when a session exists (never stores raw session ids on the context).
+ */
+public final class HttpSessionSessionInspector implements SessionInspector {
+
+    @Override
+    public SessionContext inspect(HttpServletRequest request, String identityHash) {
+        try {
+            HttpSession session = request.getSession(false);
+            if (session == null) {
+                return SessionContext.none();
+            }
+            String id = session.getId();
+            if (id == null || id.isEmpty()) {
+                return SessionContext.none();
+            }
+            return SessionContext.ofHashedId(IdentityHashing.sha256Hex(id));
+        } catch (Exception e) {
+            return SessionContext.none();
+        }
+    }
+}

--- a/ai-sentinel-spring-boot-starter/src/main/java/io/aisentinel/autoconfigure/identity/IdentityAutoConfiguration.java
+++ b/ai-sentinel-spring-boot-starter/src/main/java/io/aisentinel/autoconfigure/identity/IdentityAutoConfiguration.java
@@ -1,0 +1,72 @@
+package io.aisentinel.autoconfigure.identity;
+
+import io.aisentinel.autoconfigure.config.SentinelAutoConfiguration;
+import io.aisentinel.core.identity.spi.AuthenticationInspector;
+import io.aisentinel.core.identity.spi.IdentityContextResolver;
+import io.aisentinel.core.identity.spi.IdentityResponseHook;
+import io.aisentinel.core.identity.spi.NoopIdentityContextResolver;
+import io.aisentinel.core.identity.spi.NoopIdentityResponseHook;
+import io.aisentinel.core.identity.spi.NoopTrustEvaluator;
+import io.aisentinel.core.identity.spi.SessionInspector;
+import io.aisentinel.core.identity.spi.TrustEvaluator;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
+import org.springframework.context.annotation.Bean;
+
+/**
+ * Phase 0 identity foundation: conditional beans for {@link io.aisentinel.core.model.RequestContext} population and hooks.
+ * When {@code ai.sentinel.identity.enabled=false} (default), no-op implementations preserve existing API security behavior.
+ */
+@AutoConfiguration(before = SentinelAutoConfiguration.class)
+@ConditionalOnWebApplication
+@ConditionalOnProperty(name = "ai.sentinel.enabled", havingValue = "true", matchIfMissing = true)
+public class IdentityAutoConfiguration {
+
+    @Bean
+    @ConditionalOnProperty(name = "ai.sentinel.identity.enabled", havingValue = "true")
+    @ConditionalOnMissingBean(AuthenticationInspector.class)
+    public AuthenticationInspector aisentinelAuthenticationInspector() {
+        return new SpringSecurityAuthenticationInspector();
+    }
+
+    @Bean
+    @ConditionalOnProperty(name = "ai.sentinel.identity.enabled", havingValue = "true")
+    @ConditionalOnMissingBean(SessionInspector.class)
+    public SessionInspector aisentinelSessionInspector() {
+        return new HttpSessionSessionInspector();
+    }
+
+    @Bean
+    @ConditionalOnProperty(name = "ai.sentinel.identity.enabled", havingValue = "true")
+    @ConditionalOnMissingBean(IdentityContextResolver.class)
+    public IdentityContextResolver aisentinelIdentityContextResolver(AuthenticationInspector aisentinelAuthenticationInspector,
+                                                                   SessionInspector aisentinelSessionInspector) {
+        return new ServletIdentityContextResolver(aisentinelAuthenticationInspector, aisentinelSessionInspector);
+    }
+
+    @Bean
+    @ConditionalOnProperty(name = "ai.sentinel.identity.enabled", havingValue = "false", matchIfMissing = true)
+    @ConditionalOnMissingBean(IdentityContextResolver.class)
+    public IdentityContextResolver aisentinelNoopIdentityContextResolver() {
+        return NoopIdentityContextResolver.INSTANCE;
+    }
+
+    /**
+     * Phase 0: always {@link NoopTrustEvaluator} unless the application supplies its own {@link TrustEvaluator}.
+     * Identity trust therefore remains whatever {@link IdentityContextResolver} stored (typically baseline from
+     * {@link ServletIdentityContextResolver}).
+     */
+    @Bean
+    @ConditionalOnMissingBean(TrustEvaluator.class)
+    public TrustEvaluator aisentinelDefaultTrustEvaluator() {
+        return NoopTrustEvaluator.INSTANCE;
+    }
+
+    @Bean
+    @ConditionalOnMissingBean(IdentityResponseHook.class)
+    public IdentityResponseHook aisentinelIdentityResponseHook() {
+        return NoopIdentityResponseHook.INSTANCE;
+    }
+}

--- a/ai-sentinel-spring-boot-starter/src/main/java/io/aisentinel/autoconfigure/identity/IdentityHashing.java
+++ b/ai-sentinel-spring-boot-starter/src/main/java/io/aisentinel/autoconfigure/identity/IdentityHashing.java
@@ -1,0 +1,23 @@
+package io.aisentinel.autoconfigure.identity;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
+
+final class IdentityHashing {
+
+    private IdentityHashing() {}
+
+    static String sha256Hex(String raw) {
+        if (raw == null) {
+            raw = "";
+        }
+        try {
+            byte[] digest = MessageDigest.getInstance("SHA-256").digest(raw.getBytes(StandardCharsets.UTF_8));
+            return HexFormat.of().formatHex(digest);
+        } catch (NoSuchAlgorithmException e) {
+            throw new AssertionError("SHA-256 required by JRE spec", e);
+        }
+    }
+}

--- a/ai-sentinel-spring-boot-starter/src/main/java/io/aisentinel/autoconfigure/identity/ServletIdentityContextResolver.java
+++ b/ai-sentinel-spring-boot-starter/src/main/java/io/aisentinel/autoconfigure/identity/ServletIdentityContextResolver.java
@@ -1,0 +1,34 @@
+package io.aisentinel.autoconfigure.identity;
+
+import io.aisentinel.core.identity.IdentityContextKeys;
+import io.aisentinel.core.identity.model.IdentityContext;
+import io.aisentinel.core.identity.model.IdentityRiskSignals;
+import io.aisentinel.core.identity.model.TrustScore;
+import io.aisentinel.core.identity.spi.AuthenticationInspector;
+import io.aisentinel.core.identity.spi.IdentityContextResolver;
+import io.aisentinel.core.identity.spi.SessionInspector;
+import io.aisentinel.core.model.RequestContext;
+import jakarta.servlet.http.HttpServletRequest;
+
+/**
+ * Assembles {@link IdentityContext} from servlet and optional Spring Security state.
+ */
+public final class ServletIdentityContextResolver implements IdentityContextResolver {
+
+    private final AuthenticationInspector authenticationInspector;
+    private final SessionInspector sessionInspector;
+
+    public ServletIdentityContextResolver(AuthenticationInspector authenticationInspector,
+                                        SessionInspector sessionInspector) {
+        this.authenticationInspector = authenticationInspector;
+        this.sessionInspector = sessionInspector;
+    }
+
+    @Override
+    public void resolve(HttpServletRequest request, String identityHash, RequestContext ctx) {
+        var auth = authenticationInspector.inspect(request, identityHash);
+        var session = sessionInspector.inspect(request, identityHash);
+        var identity = new IdentityContext(auth, session, TrustScore.fullyTrusted(), IdentityRiskSignals.empty());
+        ctx.put(IdentityContextKeys.IDENTITY_CONTEXT, identity);
+    }
+}

--- a/ai-sentinel-spring-boot-starter/src/main/java/io/aisentinel/autoconfigure/identity/SpringSecurityAuthenticationInspector.java
+++ b/ai-sentinel-spring-boot-starter/src/main/java/io/aisentinel/autoconfigure/identity/SpringSecurityAuthenticationInspector.java
@@ -1,0 +1,77 @@
+package io.aisentinel.autoconfigure.identity;
+
+import io.aisentinel.core.identity.model.AuthenticationContext;
+import io.aisentinel.core.identity.spi.AuthenticationInspector;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+
+import java.lang.reflect.Method;
+
+/**
+ * Resolves authentication via Spring Security when present on the classpath (reflection; no compile-time dependency).
+ * Reflective {@link Method} handles are resolved once at class initialization; the request path only invokes them.
+ */
+@Slf4j
+public final class SpringSecurityAuthenticationInspector implements AuthenticationInspector {
+
+    private static final boolean SPRING_SECURITY_REFLECTION_AVAILABLE;
+    private static final Method HOLDER_GET_CONTEXT;
+    private static final Method CONTEXT_GET_AUTHENTICATION;
+    private static final Method AUTH_IS_AUTHENTICATED;
+    private static final Method AUTH_GET_PRINCIPAL;
+    private static final Method AUTH_GET_NAME;
+
+    static {
+        Method getContext = null;
+        Method getAuthentication = null;
+        Method isAuthenticated = null;
+        Method getPrincipal = null;
+        Method getName = null;
+        boolean available = false;
+        try {
+            Class<?> holderClass = Class.forName("org.springframework.security.core.context.SecurityContextHolder");
+            Class<?> securityContextClass = Class.forName("org.springframework.security.core.context.SecurityContext");
+            Class<?> authenticationClass = Class.forName("org.springframework.security.core.Authentication");
+            getContext = holderClass.getMethod("getContext");
+            getAuthentication = securityContextClass.getMethod("getAuthentication");
+            isAuthenticated = authenticationClass.getMethod("isAuthenticated");
+            getPrincipal = authenticationClass.getMethod("getPrincipal");
+            getName = authenticationClass.getMethod("getName");
+            available = true;
+        } catch (Throwable t) {
+            log.debug("Spring Security not available for AuthenticationInspector: {}", t.toString());
+        }
+        SPRING_SECURITY_REFLECTION_AVAILABLE = available;
+        HOLDER_GET_CONTEXT = getContext;
+        CONTEXT_GET_AUTHENTICATION = getAuthentication;
+        AUTH_IS_AUTHENTICATED = isAuthenticated;
+        AUTH_GET_PRINCIPAL = getPrincipal;
+        AUTH_GET_NAME = getName;
+    }
+
+    @Override
+    public AuthenticationContext inspect(HttpServletRequest request, String identityHash) {
+        if (!SPRING_SECURITY_REFLECTION_AVAILABLE) {
+            return AuthenticationContext.unauthenticated();
+        }
+        try {
+            Object securityContext = HOLDER_GET_CONTEXT.invoke(null);
+            if (securityContext == null) {
+                return AuthenticationContext.unauthenticated();
+            }
+            Object auth = CONTEXT_GET_AUTHENTICATION.invoke(securityContext);
+            if (auth == null || !Boolean.TRUE.equals(AUTH_IS_AUTHENTICATED.invoke(auth))) {
+                return AuthenticationContext.unauthenticated();
+            }
+            Object principal = AUTH_GET_PRINCIPAL.invoke(auth);
+            if (principal == null || "anonymousUser".equals(principal.toString())) {
+                return AuthenticationContext.unauthenticated();
+            }
+            String name = AUTH_GET_NAME.invoke(auth).toString();
+            return AuthenticationContext.ofPrincipal(name);
+        } catch (ReflectiveOperationException e) {
+            log.debug("Spring Security authentication inspection failed: {}", e.toString());
+            return AuthenticationContext.unauthenticated();
+        }
+    }
+}

--- a/ai-sentinel-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/ai-sentinel-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,3 +1,4 @@
+io.aisentinel.autoconfigure.identity.IdentityAutoConfiguration
 io.aisentinel.autoconfigure.distributed.DistributedQuarantineStatusAutoConfiguration
 io.aisentinel.autoconfigure.distributed.DistributedThrottleStatusAutoConfiguration
 io.aisentinel.autoconfigure.distributed.DistributedQuarantineAutoConfiguration

--- a/ai-sentinel-spring-boot-starter/src/test/java/io/aisentinel/autoconfigure/config/SentinelAutoConfigurationTest.java
+++ b/ai-sentinel-spring-boot-starter/src/test/java/io/aisentinel/autoconfigure/config/SentinelAutoConfigurationTest.java
@@ -1,6 +1,8 @@
 package io.aisentinel.autoconfigure.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.aisentinel.autoconfigure.identity.IdentityAutoConfiguration;
+import io.aisentinel.autoconfigure.identity.ServletIdentityContextResolver;
 import io.aisentinel.autoconfigure.distributed.DistributedQuarantineAutoConfiguration;
 import io.aisentinel.autoconfigure.model.ModelRefreshScheduler;
 import io.aisentinel.autoconfigure.model.ModelRegistryAutoConfiguration;
@@ -10,6 +12,10 @@ import io.aisentinel.autoconfigure.distributed.quarantine.RedisClusterQuarantine
 import io.aisentinel.autoconfigure.distributed.quarantine.RedisClusterQuarantineWriter;
 import io.aisentinel.autoconfigure.distributed.throttle.RedisClusterThrottleStore;
 import io.aisentinel.autoconfigure.web.SentinelFilter;
+import io.aisentinel.core.identity.spi.IdentityContextResolver;
+import io.aisentinel.core.identity.spi.NoopIdentityContextResolver;
+import io.aisentinel.core.identity.spi.NoopTrustEvaluator;
+import io.aisentinel.core.identity.spi.TrustEvaluator;
 import io.aisentinel.core.model.RequestFeatures;
 import io.aisentinel.core.policy.EnforcementAction;
 import io.aisentinel.core.policy.PolicyEngine;
@@ -43,7 +49,7 @@ import static org.mockito.Mockito.when;
 class SentinelAutoConfigurationTest {
 
     private final WebApplicationContextRunner contextRunner = new WebApplicationContextRunner()
-        .withConfiguration(AutoConfigurations.of(SentinelAutoConfiguration.class));
+        .withConfiguration(AutoConfigurations.of(IdentityAutoConfiguration.class, SentinelAutoConfiguration.class));
 
     private static RequestFeatures dummyFeatures() {
         return RequestFeatures.builder()
@@ -67,6 +73,25 @@ class SentinelAutoConfigurationTest {
             .run(context -> {
                 assertThat(context).hasSingleBean(io.aisentinel.core.SentinelPipeline.class);
                 assertThat(context).hasSingleBean(SentinelFilter.class);
+            });
+    }
+
+    @Test
+    void identityFoundationUsesNoopResolverByDefault() {
+        contextRunner
+            .withPropertyValues("ai.sentinel.enabled=true")
+            .run(context -> {
+                assertThat(context.getBean(IdentityContextResolver.class)).isSameAs(NoopIdentityContextResolver.INSTANCE);
+            });
+    }
+
+    @Test
+    void identityFoundationRegistersServletResolverWhenEnabled() {
+        contextRunner
+            .withPropertyValues("ai.sentinel.enabled=true", "ai.sentinel.identity.enabled=true")
+            .run(context -> {
+                assertThat(context.getBean(IdentityContextResolver.class)).isInstanceOf(ServletIdentityContextResolver.class);
+                assertThat(context.getBean(TrustEvaluator.class)).isSameAs(NoopTrustEvaluator.INSTANCE);
             });
     }
 

--- a/ai-sentinel-spring-boot-starter/src/test/java/io/aisentinel/autoconfigure/config/SentinelPropertiesTest.java
+++ b/ai-sentinel-spring-boot-starter/src/test/java/io/aisentinel/autoconfigure/config/SentinelPropertiesTest.java
@@ -26,6 +26,7 @@ class SentinelPropertiesTest {
             assertThat(props.getBaselineTtl()).isEqualTo(Duration.ofMinutes(5));
             assertThat(props.getIsolationForest().isEnabled()).isFalse();
             assertThat(props.getDistributed().isClusterQuarantineWriteEnabled()).isFalse();
+            assertThat(props.getIdentity().isEnabled()).isFalse();
         });
     }
 

--- a/ai-sentinel-spring-boot-starter/src/test/java/io/aisentinel/autoconfigure/identity/SpringSecurityAuthenticationInspectorTest.java
+++ b/ai-sentinel-spring-boot-starter/src/test/java/io/aisentinel/autoconfigure/identity/SpringSecurityAuthenticationInspectorTest.java
@@ -1,0 +1,40 @@
+package io.aisentinel.autoconfigure.identity;
+
+import io.aisentinel.core.identity.model.AuthenticationContext;
+import jakarta.servlet.http.HttpServletRequest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+class SpringSecurityAuthenticationInspectorTest {
+
+    private final SpringSecurityAuthenticationInspector inspector = new SpringSecurityAuthenticationInspector();
+
+    @AfterEach
+    void clearSecurityContext() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    void returnsUnauthenticatedWhenNoSecurityContext() {
+        SecurityContextHolder.clearContext();
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        assertThat(inspector.inspect(request, "hash"))
+            .isEqualTo(AuthenticationContext.unauthenticated());
+    }
+
+    @Test
+    void returnsPrincipalWhenAuthenticated() {
+        SecurityContextHolder.getContext().setAuthentication(
+            new UsernamePasswordAuthenticationToken("alice", "cred", List.of()));
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        assertThat(inspector.inspect(request, "hash"))
+            .isEqualTo(AuthenticationContext.ofPrincipal("alice"));
+    }
+}


### PR DESCRIPTION
Introduces **Phase 0 — Identity Foundation** for the Identity arm: minimal domain types, SPI extension points, `RequestContext` storage, and Spring Boot autoconfiguration **without** changing default API security behavior. Identity remains **off by default** (`ai.sentinel.identity.enabled=false`).
Includes a small **hardening/cleanup** pass (SHA-256 failure handling, cached Spring Security reflection for the inspector, removal of redundant APIs, single default `TrustEvaluator`, targeted tests).
## What changed
### Core (`ai-sentinel-core`)
- **Models:** `IdentityContext`, `AuthenticationContext`, `SessionContext`, `TrustScore`, `IdentityRiskSignals`
- **SPI:** `IdentityContextResolver`, `AuthenticationInspector`, `SessionInspector`, `TrustEvaluator`, `IdentityResponseHook` plus no-op defaults
- **`SentinelPipeline`:** resolve identity → extract features → optional trust hook (does **not** affect anomaly score or policy) → existing scoring / policy / enforcement; response hook in `finally` when features were extracted
### Starter (`ai-sentinel-spring-boot-starter`)
- **`SentinelProperties`:** nested `identity.enabled` (default `false`)
- **`IdentityAutoConfiguration`:** conditional beans; registered in `AutoConfiguration.imports` before `SentinelAutoConfiguration`
- **Default wiring when identity enabled:** `ServletIdentityContextResolver`, `SpringSecurityAuthenticationInspector` (reflection, no compile-time Security dependency), `HttpSessionSessionInspector`, `IdentityHashing` for session id hashing
- **`SentinelAutoConfiguration`:** injects identity SPI beans into `SentinelPipeline` with `ObjectProvider` fallbacks
