### PR TITLE
Phase 1: normalized identity context extraction

### DIFF
--- a/ai-sentinel-core/src/main/java/io/aisentinel/core/identity/model/AuthenticationContext.java
+++ b/ai-sentinel-core/src/main/java/io/aisentinel/core/identity/model/AuthenticationContext.java
@@ -1,25 +1,64 @@
 package io.aisentinel.core.identity.model;
 
+import java.util.List;
 import java.util.Objects;
 
 /**
  * Snapshot of authentication state for the current request (no raw credentials).
+ * <p>
+ * Distinguish: {@code authenticationInfrastructurePresent == false} means Spring Security could not be
+ * introspected (types absent). {@code authenticated == false} with infrastructure present means the
+ * caller is not logged in or is the anonymous principal.
  */
 public record AuthenticationContext(
     boolean authenticated,
     boolean anonymous,
-    String principalName
+    String principalName,
+    /** Simple name of the {@code Authentication} implementation when known (e.g. Bearer), otherwise empty. */
+    String authenticationType,
+    /** Granted authority strings (e.g. roles), capped by the inspector; immutable. */
+    List<String> roleNames,
+    /**
+     * {@code false} when Spring Security was not available for introspection; {@code true} when the
+     * security API was usable for this request (including anonymous/unauthenticated outcomes).
+     */
+    boolean authenticationInfrastructurePresent
 ) {
     public AuthenticationContext {
         principalName = principalName != null ? principalName : "";
+        authenticationType = authenticationType != null ? authenticationType : "";
+        roleNames = roleNames != null ? List.copyOf(roleNames) : List.of();
     }
 
+    /** Anonymous / not logged in; security API assumed available (typical servlet + optional SS). */
     public static AuthenticationContext unauthenticated() {
-        return new AuthenticationContext(false, true, "");
+        return unauthenticated(true);
     }
 
+    /**
+     * @param authenticationInfrastructurePresent use {@code false} only when security types cannot be loaded
+     */
+    public static AuthenticationContext unauthenticated(boolean authenticationInfrastructurePresent) {
+        return new AuthenticationContext(false, true, "", "", List.of(), authenticationInfrastructurePresent);
+    }
+
+    /** Authenticated user with only principal known (minimal). */
     public static AuthenticationContext ofPrincipal(String name) {
         Objects.requireNonNull(name, "name");
-        return new AuthenticationContext(true, false, name);
+        return ofAuthenticated(name, "", List.of());
+    }
+
+    public static AuthenticationContext ofAuthenticated(String principalName,
+                                                         String authenticationType,
+                                                         List<String> roleNames) {
+        Objects.requireNonNull(principalName, "principalName");
+        return new AuthenticationContext(
+            true,
+            false,
+            principalName,
+            authenticationType != null ? authenticationType : "",
+            roleNames != null ? List.copyOf(roleNames) : List.of(),
+            true
+        );
     }
 }

--- a/ai-sentinel-core/src/main/java/io/aisentinel/core/identity/model/IdentityContext.java
+++ b/ai-sentinel-core/src/main/java/io/aisentinel/core/identity/model/IdentityContext.java
@@ -2,6 +2,11 @@ package io.aisentinel.core.identity.model;
 
 /**
  * Identity-centric view for a single request, carried in {@link io.aisentinel.core.model.RequestContext}.
+ * <ul>
+ *   <li><strong>Feature off</strong> — {@link io.aisentinel.core.identity.spi.NoopIdentityContextResolver}: key absent.</li>
+ *   <li><strong>Feature on</strong> — resolver stores this record: unauthenticated users still get explicit
+ *       {@link AuthenticationContext} (and {@link SessionContext}); see {@link AuthenticationContext#authenticationInfrastructurePresent()}.</li>
+ * </ul>
  */
 public record IdentityContext(
     AuthenticationContext authentication,

--- a/ai-sentinel-core/src/main/java/io/aisentinel/core/identity/model/SessionContext.java
+++ b/ai-sentinel-core/src/main/java/io/aisentinel/core/identity/model/SessionContext.java
@@ -5,17 +5,24 @@ package io.aisentinel.core.identity.model;
  */
 public record SessionContext(
     boolean present,
-    String sessionIdHash
+    String sessionIdHash,
+    /** From {@link jakarta.servlet.http.HttpSession#isNew()} when {@link #present}. */
+    boolean newSession
 ) {
     public SessionContext {
         sessionIdHash = sessionIdHash != null ? sessionIdHash : "";
     }
 
     public static SessionContext none() {
-        return new SessionContext(false, "");
+        return new SessionContext(false, "", false);
     }
 
     public static SessionContext ofHashedId(String sessionIdHash) {
-        return new SessionContext(sessionIdHash != null && !sessionIdHash.isEmpty(), sessionIdHash != null ? sessionIdHash : "");
+        return ofHashedId(sessionIdHash, false);
+    }
+
+    public static SessionContext ofHashedId(String sessionIdHash, boolean newSession) {
+        boolean hasHash = sessionIdHash != null && !sessionIdHash.isEmpty();
+        return new SessionContext(hasHash, hasHash ? sessionIdHash : "", hasHash && newSession);
     }
 }

--- a/ai-sentinel-spring-boot-starter/src/main/java/io/aisentinel/autoconfigure/identity/HttpSessionSessionInspector.java
+++ b/ai-sentinel-spring-boot-starter/src/main/java/io/aisentinel/autoconfigure/identity/HttpSessionSessionInspector.java
@@ -21,7 +21,7 @@ public final class HttpSessionSessionInspector implements SessionInspector {
             if (id == null || id.isEmpty()) {
                 return SessionContext.none();
             }
-            return SessionContext.ofHashedId(IdentityHashing.sha256Hex(id));
+            return SessionContext.ofHashedId(IdentityHashing.sha256Hex(id), session.isNew());
         } catch (Exception e) {
             return SessionContext.none();
         }

--- a/ai-sentinel-spring-boot-starter/src/main/java/io/aisentinel/autoconfigure/identity/ServletIdentityContextResolver.java
+++ b/ai-sentinel-spring-boot-starter/src/main/java/io/aisentinel/autoconfigure/identity/ServletIdentityContextResolver.java
@@ -11,7 +11,8 @@ import io.aisentinel.core.model.RequestContext;
 import jakarta.servlet.http.HttpServletRequest;
 
 /**
- * Assembles {@link IdentityContext} from servlet and optional Spring Security state.
+ * Assembles a normalized {@link IdentityContext} from {@link AuthenticationInspector} and {@link SessionInspector}
+ * (no policy or scoring side effects). Fails only if a delegate throws; the pipeline treats that as fail-open.
  */
 public final class ServletIdentityContextResolver implements IdentityContextResolver {
 

--- a/ai-sentinel-spring-boot-starter/src/main/java/io/aisentinel/autoconfigure/identity/SpringSecurityAuthenticationInspector.java
+++ b/ai-sentinel-spring-boot-starter/src/main/java/io/aisentinel/autoconfigure/identity/SpringSecurityAuthenticationInspector.java
@@ -6,6 +6,9 @@ import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
 
 import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
 
 /**
  * Resolves authentication via Spring Security when present on the classpath (reflection; no compile-time dependency).
@@ -14,12 +17,16 @@ import java.lang.reflect.Method;
 @Slf4j
 public final class SpringSecurityAuthenticationInspector implements AuthenticationInspector {
 
+    private static final int MAX_ROLE_NAMES = 32;
+
     private static final boolean SPRING_SECURITY_REFLECTION_AVAILABLE;
     private static final Method HOLDER_GET_CONTEXT;
     private static final Method CONTEXT_GET_AUTHENTICATION;
     private static final Method AUTH_IS_AUTHENTICATED;
     private static final Method AUTH_GET_PRINCIPAL;
     private static final Method AUTH_GET_NAME;
+    private static final Method AUTH_GET_AUTHORITIES;
+    private static final Method GRANTED_AUTHORITY_GET_AUTHORITY;
 
     static {
         Method getContext = null;
@@ -27,16 +34,21 @@ public final class SpringSecurityAuthenticationInspector implements Authenticati
         Method isAuthenticated = null;
         Method getPrincipal = null;
         Method getName = null;
+        Method getAuthorities = null;
+        Method gaGetAuthority = null;
         boolean available = false;
         try {
             Class<?> holderClass = Class.forName("org.springframework.security.core.context.SecurityContextHolder");
             Class<?> securityContextClass = Class.forName("org.springframework.security.core.context.SecurityContext");
             Class<?> authenticationClass = Class.forName("org.springframework.security.core.Authentication");
+            Class<?> grantedAuthorityClass = Class.forName("org.springframework.security.core.GrantedAuthority");
             getContext = holderClass.getMethod("getContext");
             getAuthentication = securityContextClass.getMethod("getAuthentication");
             isAuthenticated = authenticationClass.getMethod("isAuthenticated");
             getPrincipal = authenticationClass.getMethod("getPrincipal");
             getName = authenticationClass.getMethod("getName");
+            getAuthorities = authenticationClass.getMethod("getAuthorities");
+            gaGetAuthority = grantedAuthorityClass.getMethod("getAuthority");
             available = true;
         } catch (Throwable t) {
             log.debug("Spring Security not available for AuthenticationInspector: {}", t.toString());
@@ -47,31 +59,63 @@ public final class SpringSecurityAuthenticationInspector implements Authenticati
         AUTH_IS_AUTHENTICATED = isAuthenticated;
         AUTH_GET_PRINCIPAL = getPrincipal;
         AUTH_GET_NAME = getName;
+        AUTH_GET_AUTHORITIES = getAuthorities;
+        GRANTED_AUTHORITY_GET_AUTHORITY = gaGetAuthority;
     }
 
     @Override
     public AuthenticationContext inspect(HttpServletRequest request, String identityHash) {
         if (!SPRING_SECURITY_REFLECTION_AVAILABLE) {
-            return AuthenticationContext.unauthenticated();
+            return AuthenticationContext.unauthenticated(false);
         }
         try {
             Object securityContext = HOLDER_GET_CONTEXT.invoke(null);
             if (securityContext == null) {
-                return AuthenticationContext.unauthenticated();
+                return AuthenticationContext.unauthenticated(true);
             }
             Object auth = CONTEXT_GET_AUTHENTICATION.invoke(securityContext);
             if (auth == null || !Boolean.TRUE.equals(AUTH_IS_AUTHENTICATED.invoke(auth))) {
-                return AuthenticationContext.unauthenticated();
+                return AuthenticationContext.unauthenticated(true);
             }
             Object principal = AUTH_GET_PRINCIPAL.invoke(auth);
             if (principal == null || "anonymousUser".equals(principal.toString())) {
-                return AuthenticationContext.unauthenticated();
+                return AuthenticationContext.unauthenticated(true);
             }
-            String name = AUTH_GET_NAME.invoke(auth).toString();
-            return AuthenticationContext.ofPrincipal(name);
+            Object nameObj = AUTH_GET_NAME.invoke(auth);
+            String name = nameObj != null ? nameObj.toString() : "";
+            if (name.isEmpty()) {
+                return AuthenticationContext.unauthenticated(true);
+            }
+            String authType = auth.getClass().getSimpleName();
+            List<String> roles = extractRoleNames(auth);
+            return AuthenticationContext.ofAuthenticated(name, authType, roles);
         } catch (ReflectiveOperationException e) {
             log.debug("Spring Security authentication inspection failed: {}", e.toString());
-            return AuthenticationContext.unauthenticated();
+            return AuthenticationContext.unauthenticated(true);
         }
+    }
+
+    private static List<String> extractRoleNames(Object auth) throws ReflectiveOperationException {
+        if (AUTH_GET_AUTHORITIES == null || GRANTED_AUTHORITY_GET_AUTHORITY == null) {
+            return List.of();
+        }
+        Object raw = AUTH_GET_AUTHORITIES.invoke(auth);
+        if (!(raw instanceof Collection<?> col) || col.isEmpty()) {
+            return List.of();
+        }
+        List<String> out = new ArrayList<>(Math.min(col.size(), MAX_ROLE_NAMES));
+        for (Object ga : col) {
+            if (ga == null || out.size() >= MAX_ROLE_NAMES) {
+                break;
+            }
+            Object r = GRANTED_AUTHORITY_GET_AUTHORITY.invoke(ga);
+            if (r != null) {
+                String s = r.toString();
+                if (!s.isEmpty()) {
+                    out.add(s);
+                }
+            }
+        }
+        return List.copyOf(out);
     }
 }

--- a/ai-sentinel-spring-boot-starter/src/test/java/io/aisentinel/autoconfigure/identity/ServletIdentityContextResolverTest.java
+++ b/ai-sentinel-spring-boot-starter/src/test/java/io/aisentinel/autoconfigure/identity/ServletIdentityContextResolverTest.java
@@ -1,0 +1,115 @@
+package io.aisentinel.autoconfigure.identity;
+
+import io.aisentinel.core.identity.IdentityContextKeys;
+import io.aisentinel.core.identity.model.AuthenticationContext;
+import io.aisentinel.core.identity.model.IdentityContext;
+import io.aisentinel.core.identity.model.SessionContext;
+import io.aisentinel.core.identity.spi.AuthenticationInspector;
+import io.aisentinel.core.identity.spi.SessionInspector;
+import io.aisentinel.core.model.RequestContext;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ServletIdentityContextResolverTest {
+
+    @Mock
+    private HttpServletRequest request;
+
+    @Test
+    void normalizedUnauthenticated_visitorStoredWhenInspectorsSaySo() {
+        AuthenticationInspector auth = (r, h) -> AuthenticationContext.unauthenticated();
+        SessionInspector sess = (r, h) -> SessionContext.none();
+        var resolver = new ServletIdentityContextResolver(auth, sess);
+        RequestContext ctx = new RequestContext();
+        resolver.resolve(request, "hash", ctx);
+        IdentityContext id = ctx.get(IdentityContextKeys.IDENTITY_CONTEXT, IdentityContext.class);
+        assertThat(id).isNotNull();
+        assertThat(id.authentication().authenticated()).isFalse();
+        assertThat(id.authentication().anonymous()).isTrue();
+        assertThat(id.authentication().authenticationInfrastructurePresent()).isTrue();
+        assertThat(id.session().present()).isFalse();
+    }
+
+    @Test
+    void normalizedAuthenticated_composedFromInspectors() {
+        AuthenticationInspector auth = (r, h) ->
+            AuthenticationContext.ofAuthenticated("alice", "JwtAuthenticationToken", List.of("ROLE_USER"));
+        SessionInspector sess = (r, h) -> SessionContext.none();
+        var resolver = new ServletIdentityContextResolver(auth, sess);
+        RequestContext ctx = new RequestContext();
+        resolver.resolve(request, "h", ctx);
+        IdentityContext id = ctx.get(IdentityContextKeys.IDENTITY_CONTEXT, IdentityContext.class);
+        assertThat(id.authentication().principalName()).isEqualTo("alice");
+        assertThat(id.authentication().authenticationType()).isEqualTo("JwtAuthenticationToken");
+        assertThat(id.authentication().roleNames()).containsExactly("ROLE_USER");
+    }
+
+    @Test
+    void sessionPresent_hashedIdAndNewFlag() {
+        HttpServletRequest req = mock(HttpServletRequest.class);
+        HttpSession session = mock(HttpSession.class);
+        when(req.getSession(false)).thenReturn(session);
+        when(session.getId()).thenReturn("abc");
+        when(session.isNew()).thenReturn(true);
+        SessionInspector sess = new HttpSessionSessionInspector();
+        SessionContext sc = sess.inspect(req, "h");
+        assertThat(sc.present()).isTrue();
+        assertThat(sc.newSession()).isTrue();
+        assertThat(sc.sessionIdHash()).isNotEmpty();
+    }
+
+    @Test
+    void partialData_authAnonymousWithSession_ok() {
+        AuthenticationInspector auth = (r, h) -> AuthenticationContext.unauthenticated();
+        SessionInspector sess = (r, h) -> SessionContext.ofHashedId("deadbeef", false);
+        var resolver = new ServletIdentityContextResolver(auth, sess);
+        RequestContext ctx = new RequestContext();
+        resolver.resolve(request, "h", ctx);
+        IdentityContext id = ctx.get(IdentityContextKeys.IDENTITY_CONTEXT, IdentityContext.class);
+        assertThat(id.authentication().authenticated()).isFalse();
+        assertThat(id.session().present()).isTrue();
+        assertThat(id.session().sessionIdHash()).isEqualTo("deadbeef");
+    }
+
+    @Test
+    void endToEndSpringSecurityAndSession() {
+        SecurityContextHolder.getContext().setAuthentication(
+            new UsernamePasswordAuthenticationToken("sam", "p", List.of(new SimpleGrantedAuthority("ROLE_X"))));
+        try {
+            AuthenticationInspector authInspector = new SpringSecurityAuthenticationInspector();
+            HttpServletRequest req = mock(HttpServletRequest.class);
+            HttpSession session = mock(HttpSession.class);
+            when(req.getSession(false)).thenReturn(session);
+            when(session.getId()).thenReturn("sid");
+            when(session.isNew()).thenReturn(false);
+
+            SessionInspector sessionInspector = new HttpSessionSessionInspector();
+            var resolver = new ServletIdentityContextResolver(authInspector, sessionInspector);
+            RequestContext ctx = new RequestContext();
+            resolver.resolve(req, "h", ctx);
+            IdentityContext id = ctx.get(IdentityContextKeys.IDENTITY_CONTEXT, IdentityContext.class);
+            assertThat(id.authentication().principalName()).isEqualTo("sam");
+            assertThat(id.authentication().authenticated()).isTrue();
+            assertThat(id.authentication().roleNames()).contains("ROLE_X");
+            assertThat(id.session().present()).isTrue();
+            assertThat(id.session().newSession()).isFalse();
+        } finally {
+            SecurityContextHolder.clearContext();
+        }
+    }
+}

--- a/ai-sentinel-spring-boot-starter/src/test/java/io/aisentinel/autoconfigure/identity/SpringSecurityAuthenticationInspectorTest.java
+++ b/ai-sentinel-spring-boot-starter/src/test/java/io/aisentinel/autoconfigure/identity/SpringSecurityAuthenticationInspectorTest.java
@@ -5,6 +5,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 
 import java.util.List;
@@ -35,6 +36,14 @@ class SpringSecurityAuthenticationInspectorTest {
             new UsernamePasswordAuthenticationToken("alice", "cred", List.of()));
         HttpServletRequest request = mock(HttpServletRequest.class);
         assertThat(inspector.inspect(request, "hash"))
-            .isEqualTo(AuthenticationContext.ofPrincipal("alice"));
+            .isEqualTo(AuthenticationContext.ofAuthenticated("alice", "UsernamePasswordAuthenticationToken", List.of()));
+    }
+
+    @Test
+    void returnsRoleNamesWhenAuthoritiesPresent() {
+        SecurityContextHolder.getContext().setAuthentication(
+            new UsernamePasswordAuthenticationToken("bob", "c", List.of(new SimpleGrantedAuthority("ROLE_APP"))));
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        assertThat(inspector.inspect(request, "hash").roleNames()).containsExactly("ROLE_APP");
     }
 }


### PR DESCRIPTION
Implements **Phase 1 — Identity Context Extraction** on top of the Phase 0 foundation: a **normalized, structured `IdentityContext`** in `RequestContext` when `ai.sentinel.identity.enabled=true`, without changing API anomaly **scoring**, **policy**, or **enforcement**.
## What changed
### Core (`ai-sentinel-core`)
- **`AuthenticationContext`**
  - `authenticationType` — simple name of the Spring Security `Authentication` implementation when available (e.g. JWT / username-password token types).
  - `roleNames` — granted authority strings (bounded in the inspector), immutable list.
  - `authenticationInfrastructurePresent` — `false` only when Spring Security types could not be loaded; distinguishes “SS unavailable” from “SS available but user unauthenticated”.
- **`SessionContext`**
  - `newSession` — mirrors `HttpSession.isNew()` when a session exists.
- **`IdentityContext`**
  - Javadoc clarifies: identity **off** (no key) vs **on** with explicit unauthenticated vs authenticated shapes.

