### PR TITLE
Phase 3: trust-aware policy adjuster (default-off) + starter wiring

### DIFF
--- a/ai-sentinel-core/src/main/java/io/aisentinel/core/SentinelPipeline.java
+++ b/ai-sentinel-core/src/main/java/io/aisentinel/core/SentinelPipeline.java
@@ -16,7 +16,11 @@ import io.aisentinel.core.identity.spi.TrustEvaluator;
 import io.aisentinel.core.model.RequestContext;
 import io.aisentinel.core.model.RequestFeatures;
 import io.aisentinel.core.policy.EnforcementAction;
+import io.aisentinel.core.policy.NoopTrustPolicyAdjuster;
 import io.aisentinel.core.policy.PolicyEngine;
+import io.aisentinel.core.policy.TrustPolicyAdjuster;
+import io.aisentinel.core.policy.TrustPolicyAdjustment;
+import io.aisentinel.core.policy.TrustPolicyContextKeys;
 import io.aisentinel.core.metrics.SentinelMetrics;
 import io.aisentinel.core.runtime.StartupGrace;
 import io.aisentinel.core.scoring.AnomalyScorer;
@@ -55,6 +59,7 @@ public final class SentinelPipeline {
     private final String sentinelModeName;
     private final IdentityContextResolver identityContextResolver;
     private final TrustEvaluator trustEvaluator;
+    private final TrustPolicyAdjuster trustPolicyAdjuster;
     private final IdentityResponseHook identityResponseHook;
 
     public SentinelPipeline(FeatureExtractor featureExtractor, AnomalyScorer scorer, PolicyEngine policyEngine,
@@ -62,7 +67,8 @@ public final class SentinelPipeline {
                             SentinelMetrics metrics) {
         this(featureExtractor, scorer, null, policyEngine, enforcementHandler, telemetry, startupGrace, metrics,
             NoopTrainingCandidatePublisher.INSTANCE, EnforcementScope.IDENTITY_ENDPOINT, "default", "", "ENFORCE",
-            NoopIdentityContextResolver.INSTANCE, NoopTrustEvaluator.INSTANCE, NoopIdentityResponseHook.INSTANCE);
+            NoopIdentityContextResolver.INSTANCE, NoopTrustEvaluator.INSTANCE, NoopTrustPolicyAdjuster.INSTANCE,
+            NoopIdentityResponseHook.INSTANCE);
     }
 
     public SentinelPipeline(FeatureExtractor featureExtractor,
@@ -80,6 +86,7 @@ public final class SentinelPipeline {
                             String sentinelModeName,
                             IdentityContextResolver identityContextResolver,
                             TrustEvaluator trustEvaluator,
+                            TrustPolicyAdjuster trustPolicyAdjuster,
                             IdentityResponseHook identityResponseHook) {
         this.featureExtractor = featureExtractor;
         this.scorer = scorer;
@@ -98,6 +105,7 @@ public final class SentinelPipeline {
         this.sentinelModeName = sentinelModeName != null ? sentinelModeName : "ENFORCE";
         this.identityContextResolver = identityContextResolver != null ? identityContextResolver : NoopIdentityContextResolver.INSTANCE;
         this.trustEvaluator = trustEvaluator != null ? trustEvaluator : NoopTrustEvaluator.INSTANCE;
+        this.trustPolicyAdjuster = trustPolicyAdjuster != null ? trustPolicyAdjuster : NoopTrustPolicyAdjuster.INSTANCE;
         this.identityResponseHook = identityResponseHook != null ? identityResponseHook : NoopIdentityResponseHook.INSTANCE;
     }
 
@@ -164,6 +172,17 @@ public final class SentinelPipeline {
             double score = clampScore(rawScore);
 
             EnforcementAction action = policyEngine.evaluate(score, features, features.endpoint());
+            try {
+                TrustPolicyAdjustment tp = trustPolicyAdjuster.adjust(action, score, features, features.endpoint(),
+                    request, ctx);
+                action = tp.action();
+                if (tp.trustPolicyDetail() != null && !tp.trustPolicyDetail().isBlank()) {
+                    ctx.put(TrustPolicyContextKeys.TRUST_POLICY_DETAIL, tp.trustPolicyDetail());
+                }
+            } catch (Exception e) {
+                log.debug("Trust policy adjustment failed for {}: {}", features.endpoint(), e.getMessage());
+                metrics.recordFailOpen();
+            }
 
             telemetry.emit(TelemetryEvent.threatScored(identityHash, features.endpoint(), score));
             if (score > 0.5) {

--- a/ai-sentinel-core/src/main/java/io/aisentinel/core/policy/DefaultTrustPolicyAdjuster.java
+++ b/ai-sentinel-core/src/main/java/io/aisentinel/core/policy/DefaultTrustPolicyAdjuster.java
@@ -1,0 +1,141 @@
+package io.aisentinel.core.policy;
+
+import io.aisentinel.core.identity.IdentityContextKeys;
+import io.aisentinel.core.identity.model.AuthenticationContext;
+import io.aisentinel.core.identity.model.IdentityContext;
+import io.aisentinel.core.model.RequestContext;
+import io.aisentinel.core.model.RequestFeatures;
+import jakarta.servlet.http.HttpServletRequest;
+
+import java.util.Locale;
+
+/**
+ * Threshold-based trust policy: escalates {@link EnforcementAction} only (never relaxes anomaly policy).
+ */
+public final class DefaultTrustPolicyAdjuster implements TrustPolicyAdjuster {
+
+    private final TrustPolicyConfig config;
+
+    public DefaultTrustPolicyAdjuster(TrustPolicyConfig config) {
+        this.config = config != null ? config : TrustPolicyConfig.disabled();
+    }
+
+    @Override
+    public TrustPolicyAdjustment adjust(EnforcementAction baseline,
+                                        double riskScore,
+                                        RequestFeatures features,
+                                        String endpoint,
+                                        HttpServletRequest request,
+                                        RequestContext ctx) {
+        if (!config.enabled()) {
+            return new TrustPolicyAdjustment(baseline, "");
+        }
+        IdentityContext identity = ctx != null
+            ? ctx.get(IdentityContextKeys.IDENTITY_CONTEXT, IdentityContext.class)
+            : null;
+        if (identity == null) {
+            return new TrustPolicyAdjustment(baseline, "");
+        }
+        if (config.authenticatedOnly()) {
+            AuthenticationContext auth = identity.authentication();
+            if (!auth.authenticated() || auth.anonymous()) {
+                return new TrustPolicyAdjustment(baseline, "");
+            }
+        }
+        return escalateGivenTrust(identity.trust().value(), baseline, riskScore, features, endpoint, request);
+    }
+
+    /**
+     * Trust-band escalation after identity gates; package-private for tests (e.g. raw {@code NaN} without
+     * {@link io.aisentinel.core.identity.model.TrustScore} canonicalization).
+     */
+    TrustPolicyAdjustment escalateGivenTrust(double trust,
+                                             EnforcementAction baseline,
+                                             double riskScore,
+                                             RequestFeatures features,
+                                             String endpoint,
+                                             HttpServletRequest request) {
+        if (Double.isNaN(trust)) {
+            return new TrustPolicyAdjustment(baseline, "");
+        }
+        String method = request != null && request.getMethod() != null ? request.getMethod().toUpperCase(Locale.ROOT) : "";
+        boolean protectedEp = isProtectedEndpoint(endpoint != null ? endpoint : "", method);
+
+        EnforcementAction floor = trustFloor(trust, protectedEp, riskScore);
+        if (floor == null) {
+            return new TrustPolicyAdjustment(baseline, "");
+        }
+        EnforcementAction merged = maxSeverity(baseline, floor);
+        if (merged == baseline) {
+            return new TrustPolicyAdjustment(baseline, "");
+        }
+        String detail = "trust-policy:trust=" + round4(trust)
+            + ";floor=" + floor
+            + ";protected=" + protectedEp
+            + ";risk=" + round4(riskScore)
+            + ";merged=" + merged;
+        return new TrustPolicyAdjustment(merged, detail);
+    }
+
+    private EnforcementAction trustFloor(double trust, boolean protectedEndpoint, double riskScore) {
+        if (trust >= config.trustNoEffectMinimum()) {
+            return null;
+        }
+        if (trust >= config.trustMediumBandMinimum()) {
+            return EnforcementAction.MONITOR;
+        }
+        if (trust >= config.trustLowBandMinimum()) {
+            return protectedEndpoint ? EnforcementAction.THROTTLE : EnforcementAction.MONITOR;
+        }
+        if (protectedEndpoint && config.denyOnCriticalTrustEnabled()) {
+            boolean riskOk = !config.requireMinRiskForTrustDeny()
+                || (!Double.isNaN(riskScore) && riskScore >= config.minRiskScoreForTrustDeny());
+            if (riskOk) {
+                return EnforcementAction.BLOCK;
+            }
+        }
+        return protectedEndpoint ? EnforcementAction.THROTTLE : EnforcementAction.MONITOR;
+    }
+
+    private static EnforcementAction maxSeverity(EnforcementAction a, EnforcementAction b) {
+        return a.ordinal() >= b.ordinal() ? a : b;
+    }
+
+    private boolean isProtectedEndpoint(String endpoint, String methodUpper) {
+        if (config.protectedEndpointPatterns().isEmpty()) {
+            return false;
+        }
+        if (!config.httpMethodsUpper().isEmpty() && !config.httpMethodsUpper().contains(methodUpper)) {
+            return false;
+        }
+        for (String pattern : config.protectedEndpointPatterns()) {
+            if (matchesPattern(endpoint, pattern)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    static boolean matchesPattern(String endpoint, String pattern) {
+        if (pattern == null || pattern.isEmpty()) {
+            return false;
+        }
+        String p = pattern.trim();
+        if (p.equals("/**") || p.equals("*")) {
+            return true;
+        }
+        if (p.endsWith("/**")) {
+            String base = p.substring(0, p.length() - 3);
+            return endpoint.equals(base) || endpoint.startsWith(base + "/");
+        }
+        if (p.endsWith("*") && p.length() > 1 && !p.endsWith("**")) {
+            String prefix = p.substring(0, p.length() - 1);
+            return endpoint.startsWith(prefix);
+        }
+        return endpoint.equals(p);
+    }
+
+    private static String round4(double v) {
+        return Double.isNaN(v) ? "NaN" : String.format(Locale.ROOT, "%.4f", v);
+    }
+}

--- a/ai-sentinel-core/src/main/java/io/aisentinel/core/policy/NoopTrustPolicyAdjuster.java
+++ b/ai-sentinel-core/src/main/java/io/aisentinel/core/policy/NoopTrustPolicyAdjuster.java
@@ -1,0 +1,19 @@
+package io.aisentinel.core.policy;
+
+import io.aisentinel.core.model.RequestContext;
+import io.aisentinel.core.model.RequestFeatures;
+import jakarta.servlet.http.HttpServletRequest;
+
+public enum NoopTrustPolicyAdjuster implements TrustPolicyAdjuster {
+    INSTANCE;
+
+    @Override
+    public TrustPolicyAdjustment adjust(EnforcementAction baseline,
+                                        double riskScore,
+                                        RequestFeatures features,
+                                        String endpoint,
+                                        HttpServletRequest request,
+                                        RequestContext ctx) {
+        return new TrustPolicyAdjustment(baseline, "");
+    }
+}

--- a/ai-sentinel-core/src/main/java/io/aisentinel/core/policy/TrustPolicyAdjuster.java
+++ b/ai-sentinel-core/src/main/java/io/aisentinel/core/policy/TrustPolicyAdjuster.java
@@ -1,0 +1,19 @@
+package io.aisentinel.core.policy;
+
+import io.aisentinel.core.model.RequestContext;
+import io.aisentinel.core.model.RequestFeatures;
+import jakarta.servlet.http.HttpServletRequest;
+
+/**
+ * Phase 3: optionally escalates {@link EnforcementAction} using identity trust and scope rules.
+ * Anomaly {@link PolicyEngine} output is the baseline; this layer only increases severity (never relaxes).
+ */
+public interface TrustPolicyAdjuster {
+
+    TrustPolicyAdjustment adjust(EnforcementAction baseline,
+                                 double riskScore,
+                                 RequestFeatures features,
+                                 String endpoint,
+                                 HttpServletRequest request,
+                                 RequestContext ctx);
+}

--- a/ai-sentinel-core/src/main/java/io/aisentinel/core/policy/TrustPolicyAdjustment.java
+++ b/ai-sentinel-core/src/main/java/io/aisentinel/core/policy/TrustPolicyAdjustment.java
@@ -1,0 +1,17 @@
+package io.aisentinel.core.policy;
+
+/**
+ * Result of applying trust-aware policy on top of anomaly-based {@link EnforcementAction}.
+ */
+public record TrustPolicyAdjustment(EnforcementAction action, String trustPolicyDetail) {
+    public TrustPolicyAdjustment {
+        if (action == null) {
+            throw new IllegalArgumentException("action");
+        }
+        trustPolicyDetail = trustPolicyDetail != null ? trustPolicyDetail : "";
+    }
+
+    public boolean changedFrom(EnforcementAction baseline) {
+        return baseline != action;
+    }
+}

--- a/ai-sentinel-core/src/main/java/io/aisentinel/core/policy/TrustPolicyConfig.java
+++ b/ai-sentinel-core/src/main/java/io/aisentinel/core/policy/TrustPolicyConfig.java
@@ -1,0 +1,55 @@
+package io.aisentinel.core.policy;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Immutable snapshot of trust-aware policy settings (Phase 3).
+ */
+public record TrustPolicyConfig(
+    boolean enabled,
+    boolean authenticatedOnly,
+    List<String> protectedEndpointPatterns,
+    Set<String> httpMethodsUpper,
+    double trustNoEffectMinimum,
+    double trustMediumBandMinimum,
+    double trustLowBandMinimum,
+    boolean denyOnCriticalTrustEnabled,
+    boolean requireMinRiskForTrustDeny,
+    double minRiskScoreForTrustDeny
+) {
+    public TrustPolicyConfig {
+        protectedEndpointPatterns = List.copyOf(protectedEndpointPatterns != null ? protectedEndpointPatterns : List.of());
+        httpMethodsUpper = httpMethodsUpper != null && !httpMethodsUpper.isEmpty()
+            ? httpMethodsUpper.stream().map(s -> s.toUpperCase(Locale.ROOT)).collect(Collectors.toUnmodifiableSet())
+            : Set.of();
+        validateThresholds(trustLowBandMinimum, trustMediumBandMinimum, trustNoEffectMinimum);
+    }
+
+    public static TrustPolicyConfig disabled() {
+        return new TrustPolicyConfig(
+            false,
+            true,
+            List.of(),
+            Set.of(),
+            0.80,
+            0.50,
+            0.25,
+            false,
+            true,
+            0.40);
+    }
+
+    static void validateThresholds(double low, double medium, double noEffect) {
+        if (Double.isNaN(low) || Double.isNaN(medium) || Double.isNaN(noEffect)) {
+            throw new IllegalArgumentException("trust policy thresholds must be finite");
+        }
+        if (low < 0 || noEffect > 1.0 || !(low < medium && medium < noEffect)) {
+            throw new IllegalArgumentException(
+                "trust policy thresholds must satisfy trustLowBandMinimum < trustMediumBandMinimum < trustNoEffectMinimum; got "
+                    + low + ", " + medium + ", " + noEffect);
+        }
+    }
+}

--- a/ai-sentinel-core/src/main/java/io/aisentinel/core/policy/TrustPolicyContextKeys.java
+++ b/ai-sentinel-core/src/main/java/io/aisentinel/core/policy/TrustPolicyContextKeys.java
@@ -1,0 +1,12 @@
+package io.aisentinel.core.policy;
+
+/**
+ * Request context keys for trust-aware policy (Phase 3). Values are optional diagnostics only.
+ */
+public final class TrustPolicyContextKeys {
+
+    /** Non-empty when {@link TrustPolicyAdjuster} escalates the action beyond anomaly-only policy. */
+    public static final String TRUST_POLICY_DETAIL = "io.aisentinel.trustPolicy.detail";
+
+    private TrustPolicyContextKeys() {}
+}

--- a/ai-sentinel-core/src/test/java/io/aisentinel/core/SentinelPipelineIdentityFailOpenTest.java
+++ b/ai-sentinel-core/src/test/java/io/aisentinel/core/SentinelPipelineIdentityFailOpenTest.java
@@ -11,8 +11,11 @@ import io.aisentinel.core.identity.model.SessionContext;
 import io.aisentinel.core.identity.model.TrustScore;
 import io.aisentinel.core.identity.spi.IdentityContextResolver;
 import io.aisentinel.core.identity.spi.IdentityResponseHook;
+import io.aisentinel.core.identity.spi.NoopIdentityContextResolver;
 import io.aisentinel.core.identity.spi.NoopIdentityResponseHook;
 import io.aisentinel.core.identity.spi.NoopTrustEvaluator;
+import io.aisentinel.core.policy.NoopTrustPolicyAdjuster;
+import io.aisentinel.core.policy.TrustPolicyAdjuster;
 import io.aisentinel.core.identity.spi.TrustEvaluator;
 import io.aisentinel.core.model.RequestContext;
 import io.aisentinel.core.model.RequestFeatures;
@@ -89,6 +92,7 @@ class SentinelPipelineIdentityFailOpenTest {
             "ENFORCE",
             badResolver,
             NoopTrustEvaluator.INSTANCE,
+            NoopTrustPolicyAdjuster.INSTANCE,
             NoopIdentityResponseHook.INSTANCE
         );
 
@@ -149,6 +153,59 @@ class SentinelPipelineIdentityFailOpenTest {
             "ENFORCE",
             resolver,
             badTrust,
+            NoopTrustPolicyAdjuster.INSTANCE,
+            NoopIdentityResponseHook.INSTANCE
+        );
+
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        HttpServletResponse response = mock(HttpServletResponse.class);
+        assertThat(pipeline.process(request, response, "h")).isTrue();
+        assertThat(failOpen.get()).isEqualTo(1);
+        verify(handler).apply(eq(EnforcementAction.ALLOW), eq(request), eq(response), eq("h"), eq("/api"));
+    }
+
+    @Test
+    void trustPolicyAdjusterThrowRecordsFailOpenAndRequestContinues() throws Exception {
+        AtomicInteger failOpen = new AtomicInteger();
+        SentinelMetrics metrics = new SentinelMetrics() {
+            @Override
+            public void recordFailOpen() {
+                failOpen.incrementAndGet();
+            }
+        };
+        FeatureExtractor extractor = mock(FeatureExtractor.class);
+        when(extractor.extract(any(), eq("h"), any(RequestContext.class)))
+            .thenReturn(dummyFeatures());
+        AnomalyScorer scorer = mock(AnomalyScorer.class);
+        when(scorer.score(any())).thenReturn(0.1);
+        PolicyEngine policy = mock(PolicyEngine.class);
+        when(policy.evaluate(anyDouble(), any(), eq("/api")))
+            .thenReturn(EnforcementAction.ALLOW);
+        TrustPolicyAdjuster badAdjuster = (baseline, riskScore, f, endpoint, req, ctx) -> {
+            throw new RuntimeException("trust policy boom");
+        };
+        EnforcementHandler handler = mock(EnforcementHandler.class);
+        when(handler.isQuarantined(anyString(), anyString())).thenReturn(false);
+        when(handler.apply(eq(EnforcementAction.ALLOW), any(), any(),
+            eq("h"), eq("/api"))).thenReturn(true);
+
+        SentinelPipeline pipeline = new SentinelPipeline(
+            extractor,
+            scorer,
+            null,
+            policy,
+            handler,
+            mock(TelemetryEmitter.class),
+            StartupGrace.NEVER,
+            metrics,
+            NoopTrainingCandidatePublisher.INSTANCE,
+            EnforcementScope.IDENTITY_ENDPOINT,
+            "default",
+            "",
+            "ENFORCE",
+            NoopIdentityContextResolver.INSTANCE,
+            NoopTrustEvaluator.INSTANCE,
+            badAdjuster,
             NoopIdentityResponseHook.INSTANCE
         );
 

--- a/ai-sentinel-core/src/test/java/io/aisentinel/core/SentinelPipelineTrainingPublishTest.java
+++ b/ai-sentinel-core/src/test/java/io/aisentinel/core/SentinelPipelineTrainingPublishTest.java
@@ -13,6 +13,7 @@ import io.aisentinel.core.scoring.CompositeScorer;
 import io.aisentinel.core.identity.spi.NoopIdentityContextResolver;
 import io.aisentinel.core.identity.spi.NoopIdentityResponseHook;
 import io.aisentinel.core.identity.spi.NoopTrustEvaluator;
+import io.aisentinel.core.policy.NoopTrustPolicyAdjuster;
 import io.aisentinel.core.telemetry.TelemetryEmitter;
 import io.aisentinel.distributed.training.TrainingCandidatePublishRequest;
 import io.aisentinel.distributed.training.TrainingCandidatePublisher;
@@ -71,6 +72,7 @@ class SentinelPipelineTrainingPublishTest {
             "ENFORCE",
             NoopIdentityContextResolver.INSTANCE,
             NoopTrustEvaluator.INSTANCE,
+            NoopTrustPolicyAdjuster.INSTANCE,
             NoopIdentityResponseHook.INSTANCE
         );
 

--- a/ai-sentinel-core/src/test/java/io/aisentinel/core/SentinelPipelineTrustPolicyTest.java
+++ b/ai-sentinel-core/src/test/java/io/aisentinel/core/SentinelPipelineTrustPolicyTest.java
@@ -1,0 +1,158 @@
+package io.aisentinel.core;
+
+import io.aisentinel.core.enforcement.EnforcementHandler;
+import io.aisentinel.core.feature.FeatureExtractor;
+import io.aisentinel.core.identity.IdentityContextKeys;
+import io.aisentinel.core.identity.model.AuthenticationContext;
+import io.aisentinel.core.identity.model.IdentityContext;
+import io.aisentinel.core.identity.model.IdentityRiskSignals;
+import io.aisentinel.core.identity.model.SessionContext;
+import io.aisentinel.core.identity.model.TrustScore;
+import io.aisentinel.core.identity.spi.NoopIdentityContextResolver;
+import io.aisentinel.core.identity.spi.NoopIdentityResponseHook;
+import io.aisentinel.core.identity.spi.NoopTrustEvaluator;
+import io.aisentinel.core.metrics.SentinelMetrics;
+import io.aisentinel.core.model.RequestContext;
+import io.aisentinel.core.model.RequestFeatures;
+import io.aisentinel.core.policy.EnforcementAction;
+import io.aisentinel.core.policy.PolicyEngine;
+import io.aisentinel.core.policy.TrustPolicyAdjuster;
+import io.aisentinel.core.policy.TrustPolicyAdjustment;
+import io.aisentinel.core.runtime.StartupGrace;
+import io.aisentinel.core.scoring.AnomalyScorer;
+import io.aisentinel.core.telemetry.TelemetryEmitter;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyDouble;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class SentinelPipelineTrustPolicyTest {
+
+    @Test
+    void trustPolicyDetailStoredOnContextWhenAdjusterEscalates() throws Exception {
+        FeatureExtractor extractor = mock(FeatureExtractor.class);
+        RequestFeatures features = RequestFeatures.builder()
+            .identityHash("h").endpoint("/api").timestampMillis(0)
+            .requestsPerWindow(1).endpointEntropy(0).tokenAgeSeconds(60)
+            .parameterCount(0).payloadSizeBytes(0).headerFingerprintHash(0).ipBucket(0).build();
+        when(extractor.extract(any(), eq("h"), any(RequestContext.class))).thenAnswer(inv -> {
+            RequestContext ctx = inv.getArgument(2);
+            IdentityContext ic = new IdentityContext(
+                AuthenticationContext.ofPrincipal("u"),
+                SessionContext.none(),
+                new TrustScore(0.5, "t"),
+                IdentityRiskSignals.empty());
+            ctx.put(IdentityContextKeys.IDENTITY_CONTEXT, ic);
+            return features;
+        });
+
+        AnomalyScorer scorer = mock(AnomalyScorer.class);
+        when(scorer.score(any())).thenReturn(0.05);
+
+        PolicyEngine policy = mock(PolicyEngine.class);
+        when(policy.evaluate(anyDouble(), any(), eq("/api"))).thenReturn(EnforcementAction.ALLOW);
+
+        TrustPolicyAdjuster adjuster = (baseline, riskScore, f, endpoint, request, ctx) ->
+            new TrustPolicyAdjustment(EnforcementAction.MONITOR, "trust-policy:test-escalation");
+
+        EnforcementHandler handler = mock(EnforcementHandler.class);
+        when(handler.isQuarantined(anyString(), anyString())).thenReturn(false);
+        when(handler.apply(eq(EnforcementAction.MONITOR), any(), any(), eq("h"), eq("/api"))).thenReturn(true);
+
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getMethod()).thenReturn("GET");
+
+        SentinelPipeline pipeline = new SentinelPipeline(
+            extractor,
+            scorer,
+            null,
+            policy,
+            handler,
+            mock(TelemetryEmitter.class),
+            StartupGrace.NEVER,
+            SentinelMetrics.NOOP,
+            io.aisentinel.distributed.training.NoopTrainingCandidatePublisher.INSTANCE,
+            io.aisentinel.core.enforcement.EnforcementScope.IDENTITY_ENDPOINT,
+            "default",
+            "",
+            "ENFORCE",
+            NoopIdentityContextResolver.INSTANCE,
+            NoopTrustEvaluator.INSTANCE,
+            adjuster,
+            NoopIdentityResponseHook.INSTANCE
+        );
+
+        HttpServletResponse response = mock(HttpServletResponse.class);
+        assertThat(pipeline.process(request, response, "h")).isTrue();
+        verify(handler).apply(eq(EnforcementAction.MONITOR), eq(request), eq(response), eq("h"), eq("/api"));
+    }
+
+    @Test
+    void startupGraceOverridesTrustEscalationToMonitor() throws Exception {
+        FeatureExtractor extractor = mock(FeatureExtractor.class);
+        RequestFeatures features = RequestFeatures.builder()
+            .identityHash("h").endpoint("/api").timestampMillis(0)
+            .requestsPerWindow(1).endpointEntropy(0).tokenAgeSeconds(60)
+            .parameterCount(0).payloadSizeBytes(0).headerFingerprintHash(0).ipBucket(0).build();
+        when(extractor.extract(any(), eq("h"), any(RequestContext.class))).thenAnswer(inv -> {
+            RequestContext ctx = inv.getArgument(2);
+            IdentityContext ic = new IdentityContext(
+                AuthenticationContext.ofPrincipal("u"),
+                SessionContext.none(),
+                new TrustScore(0.1, "t"),
+                IdentityRiskSignals.empty());
+            ctx.put(IdentityContextKeys.IDENTITY_CONTEXT, ic);
+            return features;
+        });
+
+        AnomalyScorer scorer = mock(AnomalyScorer.class);
+        when(scorer.score(any())).thenReturn(0.05);
+
+        PolicyEngine policy = mock(PolicyEngine.class);
+        when(policy.evaluate(anyDouble(), any(), eq("/api"))).thenReturn(EnforcementAction.ALLOW);
+
+        TrustPolicyAdjuster adjuster = (baseline, riskScore, f, endpoint, request, ctx) ->
+            new TrustPolicyAdjustment(EnforcementAction.THROTTLE, "trust-policy:escalate");
+
+        EnforcementHandler handler = mock(EnforcementHandler.class);
+        when(handler.isQuarantined(anyString(), anyString())).thenReturn(false);
+        when(handler.apply(eq(EnforcementAction.MONITOR), any(), any(), eq("h"), eq("/api"))).thenReturn(true);
+
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getMethod()).thenReturn("GET");
+
+        StartupGrace graceActive = () -> true;
+
+        SentinelPipeline pipeline = new SentinelPipeline(
+            extractor,
+            scorer,
+            null,
+            policy,
+            handler,
+            mock(TelemetryEmitter.class),
+            graceActive,
+            SentinelMetrics.NOOP,
+            io.aisentinel.distributed.training.NoopTrainingCandidatePublisher.INSTANCE,
+            io.aisentinel.core.enforcement.EnforcementScope.IDENTITY_ENDPOINT,
+            "default",
+            "",
+            "ENFORCE",
+            NoopIdentityContextResolver.INSTANCE,
+            NoopTrustEvaluator.INSTANCE,
+            adjuster,
+            NoopIdentityResponseHook.INSTANCE
+        );
+
+        HttpServletResponse response = mock(HttpServletResponse.class);
+        assertThat(pipeline.process(request, response, "h")).isTrue();
+        verify(handler).apply(eq(EnforcementAction.MONITOR), eq(request), eq(response), eq("h"), eq("/api"));
+    }
+}

--- a/ai-sentinel-core/src/test/java/io/aisentinel/core/policy/DefaultTrustPolicyAdjusterTest.java
+++ b/ai-sentinel-core/src/test/java/io/aisentinel/core/policy/DefaultTrustPolicyAdjusterTest.java
@@ -1,0 +1,215 @@
+package io.aisentinel.core.policy;
+
+import io.aisentinel.core.identity.IdentityContextKeys;
+import io.aisentinel.core.identity.model.AuthenticationContext;
+import io.aisentinel.core.identity.model.IdentityContext;
+import io.aisentinel.core.identity.model.IdentityRiskSignals;
+import io.aisentinel.core.identity.model.SessionContext;
+import io.aisentinel.core.identity.model.TrustScore;
+import io.aisentinel.core.model.RequestContext;
+import io.aisentinel.core.model.RequestFeatures;
+import jakarta.servlet.http.HttpServletRequest;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class DefaultTrustPolicyAdjusterTest {
+
+    private static RequestFeatures features(String endpoint) {
+        return RequestFeatures.builder()
+            .identityHash("h")
+            .endpoint(endpoint)
+            .timestampMillis(1L)
+            .requestsPerWindow(1)
+            .endpointEntropy(0)
+            .tokenAgeSeconds(60)
+            .parameterCount(0)
+            .payloadSizeBytes(0)
+            .headerFingerprintHash(0)
+            .ipBucket(0)
+            .build();
+    }
+
+    private static RequestContext ctx(IdentityContext ic) {
+        RequestContext c = new RequestContext();
+        if (ic != null) {
+            c.put(IdentityContextKeys.IDENTITY_CONTEXT, ic);
+        }
+        return c;
+    }
+
+    private static IdentityContext authUser(double trust) {
+        return new IdentityContext(
+            AuthenticationContext.ofPrincipal("alice"),
+            SessionContext.none(),
+            new TrustScore(trust, "t"),
+            IdentityRiskSignals.empty());
+    }
+
+    private static HttpServletRequest post(String path) {
+        HttpServletRequest r = mock(HttpServletRequest.class);
+        when(r.getMethod()).thenReturn("POST");
+        return r;
+    }
+
+    @Test
+    void disabledLeavesBaselineUnchanged() {
+        DefaultTrustPolicyAdjuster adj = new DefaultTrustPolicyAdjuster(TrustPolicyConfig.disabled());
+        TrustPolicyAdjustment out = adj.adjust(EnforcementAction.ALLOW, 0.1, features("/x"), "/x",
+            post("/x"), ctx(authUser(0.1)));
+        assertThat(out.action()).isEqualTo(EnforcementAction.ALLOW);
+        assertThat(out.trustPolicyDetail()).isEmpty();
+    }
+
+    @Test
+    void highTrustNoEffect() {
+        TrustPolicyConfig cfg = new TrustPolicyConfig(
+            true, true, List.of("/api/admin/**"), Set.of(),
+            0.80, 0.50, 0.25, true, true, 0.40);
+        DefaultTrustPolicyAdjuster adj = new DefaultTrustPolicyAdjuster(cfg);
+        TrustPolicyAdjustment out = adj.adjust(EnforcementAction.ALLOW, 0.9, features("/api/admin/p"), "/api/admin/p",
+            post("/api/admin/p"), ctx(authUser(0.85)));
+        assertThat(out.action()).isEqualTo(EnforcementAction.ALLOW);
+    }
+
+    @Test
+    void mediumTrustEscalatesToMonitor() {
+        TrustPolicyConfig cfg = new TrustPolicyConfig(
+            true, true, List.of(), Set.of(),
+            0.80, 0.50, 0.25, false, true, 0.40);
+        DefaultTrustPolicyAdjuster adj = new DefaultTrustPolicyAdjuster(cfg);
+        TrustPolicyAdjustment out = adj.adjust(EnforcementAction.ALLOW, 0.05, features("/public"), "/public",
+            post("/public"), ctx(authUser(0.60)));
+        assertThat(out.action()).isEqualTo(EnforcementAction.MONITOR);
+        assertThat(out.trustPolicyDetail()).contains("trust-policy:");
+    }
+
+    @Test
+    void lowTrustOnUnprotectedOnlyMonitor() {
+        TrustPolicyConfig cfg = new TrustPolicyConfig(
+            true, true, List.of("/api/admin/**"), Set.of(),
+            0.80, 0.50, 0.25, true, true, 0.40);
+        DefaultTrustPolicyAdjuster adj = new DefaultTrustPolicyAdjuster(cfg);
+        TrustPolicyAdjustment out = adj.adjust(EnforcementAction.ALLOW, 0.05, features("/other"), "/other",
+            post("/other"), ctx(authUser(0.40)));
+        assertThat(out.action()).isEqualTo(EnforcementAction.MONITOR);
+    }
+
+    @Test
+    void lowTrustOnProtectedThrottle() {
+        TrustPolicyConfig cfg = new TrustPolicyConfig(
+            true, true, List.of("/api/admin/**"), Set.of(),
+            0.80, 0.50, 0.25, false, true, 0.40);
+        DefaultTrustPolicyAdjuster adj = new DefaultTrustPolicyAdjuster(cfg);
+        TrustPolicyAdjustment out = adj.adjust(EnforcementAction.ALLOW, 0.05, features("/api/admin/x"), "/api/admin/x",
+            post("/api/admin/x"), ctx(authUser(0.40)));
+        assertThat(out.action()).isEqualTo(EnforcementAction.THROTTLE);
+    }
+
+    @Test
+    void criticalOnProtectedDenyWhenRiskSatisfied() {
+        TrustPolicyConfig cfg = new TrustPolicyConfig(
+            true, true, List.of("/api/admin/**"), Set.of(),
+            0.80, 0.50, 0.25, true, true, 0.40);
+        DefaultTrustPolicyAdjuster adj = new DefaultTrustPolicyAdjuster(cfg);
+        TrustPolicyAdjustment out = adj.adjust(EnforcementAction.ALLOW, 0.55, features("/api/admin/x"), "/api/admin/x",
+            post("/api/admin/x"), ctx(authUser(0.10)));
+        assertThat(out.action()).isEqualTo(EnforcementAction.BLOCK);
+        assertThat(out.trustPolicyDetail()).contains("merged=BLOCK");
+    }
+
+    @Test
+    void criticalDenyRequiresRiskWhenConfigured() {
+        TrustPolicyConfig cfg = new TrustPolicyConfig(
+            true, true, List.of("/api/admin/**"), Set.of(),
+            0.80, 0.50, 0.25, true, true, 0.40);
+        DefaultTrustPolicyAdjuster adj = new DefaultTrustPolicyAdjuster(cfg);
+        TrustPolicyAdjustment out = adj.adjust(EnforcementAction.ALLOW, 0.05, features("/api/admin/x"), "/api/admin/x",
+            post("/api/admin/x"), ctx(authUser(0.10)));
+        assertThat(out.action()).isEqualTo(EnforcementAction.THROTTLE);
+    }
+
+    @Test
+    void missingIdentityNoChange() {
+        TrustPolicyConfig cfg = new TrustPolicyConfig(
+            true, true, List.of("/api/**"), Set.of(),
+            0.80, 0.50, 0.25, true, true, 0.40);
+        DefaultTrustPolicyAdjuster adj = new DefaultTrustPolicyAdjuster(cfg);
+        TrustPolicyAdjustment out = adj.adjust(EnforcementAction.ALLOW, 0.99, features("/api/x"), "/api/x",
+            post("/api/x"), ctx(null));
+        assertThat(out.action()).isEqualTo(EnforcementAction.ALLOW);
+    }
+
+    @Test
+    void authenticatedOnlySkipsAnonymous() {
+        TrustPolicyConfig cfg = new TrustPolicyConfig(
+            true, true, List.of("/api/**"), Set.of(),
+            0.80, 0.50, 0.25, true, true, 0.40);
+        DefaultTrustPolicyAdjuster adj = new DefaultTrustPolicyAdjuster(cfg);
+        IdentityContext anon = new IdentityContext(
+            AuthenticationContext.unauthenticated(),
+            SessionContext.none(),
+            new TrustScore(0.05, "t"),
+            IdentityRiskSignals.empty());
+        TrustPolicyAdjustment out = adj.adjust(EnforcementAction.ALLOW, 0.99, features("/api/x"), "/api/x",
+            post("/api/x"), ctx(anon));
+        assertThat(out.action()).isEqualTo(EnforcementAction.ALLOW);
+    }
+
+    @Test
+    void neverRelaxesBaseline() {
+        TrustPolicyConfig cfg = new TrustPolicyConfig(
+            true, true, List.of(), Set.of(),
+            0.80, 0.50, 0.25, false, true, 0.40);
+        DefaultTrustPolicyAdjuster adj = new DefaultTrustPolicyAdjuster(cfg);
+        TrustPolicyAdjustment out = adj.adjust(EnforcementAction.BLOCK, 0.05, features("/x"), "/x",
+            post("/x"), ctx(authUser(0.99)));
+        assertThat(out.action()).isEqualTo(EnforcementAction.BLOCK);
+    }
+
+    @Test
+    void httpMethodScopeRestrictsProtectedMatch() {
+        TrustPolicyConfig cfg = new TrustPolicyConfig(
+            true, true, List.of("/api/admin/**"), Set.of("GET"),
+            0.80, 0.50, 0.25, true, true, 0.40);
+        DefaultTrustPolicyAdjuster adj = new DefaultTrustPolicyAdjuster(cfg);
+        TrustPolicyAdjustment postNotProtected = adj.adjust(EnforcementAction.ALLOW, 0.99, features("/api/admin/x"),
+            "/api/admin/x", post("/api/admin/x"), ctx(authUser(0.10)));
+        assertThat(postNotProtected.action()).isEqualTo(EnforcementAction.MONITOR);
+
+        HttpServletRequest get = mock(HttpServletRequest.class);
+        when(get.getMethod()).thenReturn("GET");
+        TrustPolicyAdjustment getDenied = adj.adjust(EnforcementAction.ALLOW, 0.99, features("/api/admin/x"),
+            "/api/admin/x", get, ctx(authUser(0.10)));
+        assertThat(getDenied.action()).isEqualTo(EnforcementAction.BLOCK);
+    }
+
+    @Test
+    void matchesPatternSubtree() {
+        assertThat(DefaultTrustPolicyAdjuster.matchesPattern("/api/admin/users", "/api/admin/**")).isTrue();
+        assertThat(DefaultTrustPolicyAdjuster.matchesPattern("/api/other", "/api/admin/**")).isFalse();
+        assertThat(DefaultTrustPolicyAdjuster.matchesPattern("/api/admin", "/api/admin/**")).isTrue();
+    }
+
+    @Test
+    void nanTrustLeavesBaselineUnchanged() {
+        TrustPolicyConfig cfg = new TrustPolicyConfig(
+            true, true, List.of("/api/**"), Set.of(),
+            0.80, 0.50, 0.25, true, true, 0.40);
+        DefaultTrustPolicyAdjuster adj = new DefaultTrustPolicyAdjuster(cfg);
+        TrustPolicyAdjustment out = adj.escalateGivenTrust(
+            Double.NaN,
+            EnforcementAction.ALLOW,
+            0.99,
+            features("/api/x"),
+            "/api/x",
+            post("/api/x"));
+        assertThat(out.action()).isEqualTo(EnforcementAction.ALLOW);
+        assertThat(out.trustPolicyDetail()).isEmpty();
+    }
+}

--- a/ai-sentinel-core/src/test/java/io/aisentinel/core/policy/EnforcementActionSeverityTest.java
+++ b/ai-sentinel-core/src/test/java/io/aisentinel/core/policy/EnforcementActionSeverityTest.java
@@ -1,0 +1,26 @@
+package io.aisentinel.core.policy;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Guards the assumption used by {@link DefaultTrustPolicyAdjuster}: escalation merges by enum declaration order.
+ */
+class EnforcementActionSeverityTest {
+
+    @Test
+    void enforcementActionsAreDeclaredInAscendingSeverityOrder() {
+        EnforcementAction[] values = EnforcementAction.values();
+        assertThat(values).containsExactly(
+            EnforcementAction.ALLOW,
+            EnforcementAction.MONITOR,
+            EnforcementAction.THROTTLE,
+            EnforcementAction.BLOCK,
+            EnforcementAction.QUARANTINE
+        );
+        for (int i = 1; i < values.length; i++) {
+            assertThat(values[i].ordinal()).isGreaterThan(values[i - 1].ordinal());
+        }
+    }
+}

--- a/ai-sentinel-spring-boot-starter/src/main/java/io/aisentinel/autoconfigure/config/SentinelAutoConfiguration.java
+++ b/ai-sentinel-spring-boot-starter/src/main/java/io/aisentinel/autoconfigure/config/SentinelAutoConfiguration.java
@@ -23,8 +23,12 @@ import io.aisentinel.distributed.throttle.ClusterThrottleStore;
 import io.aisentinel.distributed.throttle.NoopClusterThrottleStore;
 import io.aisentinel.core.feature.DefaultFeatureExtractor;
 import io.aisentinel.core.feature.FeatureExtractor;
+import io.aisentinel.core.policy.DefaultTrustPolicyAdjuster;
+import io.aisentinel.core.policy.NoopTrustPolicyAdjuster;
 import io.aisentinel.core.policy.PolicyEngine;
 import io.aisentinel.core.policy.ThresholdPolicyEngine;
+import io.aisentinel.core.policy.TrustPolicyAdjuster;
+import io.aisentinel.core.policy.TrustPolicyConfig;
 import io.aisentinel.core.scoring.BoundedTrainingBuffer;
 import io.aisentinel.core.scoring.CompositeScorer;
 import io.aisentinel.core.scoring.IsolationForestConfig;
@@ -58,6 +62,11 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.context.annotation.Conditional;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
 
 /**
  * Primary Spring Boot auto-configuration for AI-Sentinel: pipeline beans, filter, optional Isolation Forest and
@@ -424,6 +433,42 @@ public class SentinelAutoConfiguration {
     }
 
     @Bean
+    @ConditionalOnMissingBean(TrustPolicyAdjuster.class)
+    public TrustPolicyAdjuster trustPolicyAdjuster(SentinelProperties props) {
+        SentinelProperties.TrustAwarePolicy tap = props.getIdentity().getTrustAwarePolicy();
+        if (tap == null || !tap.isEnabled()) {
+            return NoopTrustPolicyAdjuster.INSTANCE;
+        }
+        if (!props.getIdentity().isEnabled()) {
+            log.warn(
+                "ai.sentinel.identity.trust-aware-policy.enabled=true but ai.sentinel.identity.enabled=false; "
+                    + "trust-aware policy has no effect until identity is enabled (no IdentityContext on requests).");
+        }
+        Set<String> methodUpper = Set.of();
+        if (tap.getHttpMethods() != null && !tap.getHttpMethods().isEmpty()) {
+            methodUpper = new HashSet<>();
+            for (String m : tap.getHttpMethods()) {
+                if (m != null && !m.isBlank()) {
+                    methodUpper.add(m.trim().toUpperCase(Locale.ROOT));
+                }
+            }
+        }
+        TrustPolicyConfig cfg = new TrustPolicyConfig(
+            true,
+            tap.isAuthenticatedOnly(),
+            tap.getProtectedEndpointPatterns() != null ? tap.getProtectedEndpointPatterns() : List.of(),
+            methodUpper,
+            tap.getTrustNoEffectMinimum(),
+            tap.getTrustMediumBandMinimum(),
+            tap.getTrustLowBandMinimum(),
+            tap.isDenyOnCriticalTrustEnabled(),
+            tap.isRequireMinRiskForTrustDeny(),
+            tap.getMinRiskScoreForTrustDeny()
+        );
+        return new DefaultTrustPolicyAdjuster(cfg);
+    }
+
+    @Bean
     @ConditionalOnMissingBean
     public SentinelPipeline sentinelPipeline(FeatureExtractor featureExtractor,
                                              CompositeScorer compositeScorer,
@@ -436,6 +481,7 @@ public class SentinelAutoConfiguration {
                                              SentinelProperties props,
                                              ObjectProvider<IdentityContextResolver> identityContextResolverProvider,
                                              ObjectProvider<TrustEvaluator> trustEvaluatorProvider,
+                                             ObjectProvider<TrustPolicyAdjuster> trustPolicyAdjusterProvider,
                                              ObjectProvider<IdentityResponseHook> identityResponseHookProvider) {
         log.info("Sentinel pipeline configured (mode={})", props.getMode());
         String nodeId = props.getDistributed().getTrainingPublisherNodeId();
@@ -449,6 +495,10 @@ public class SentinelAutoConfiguration {
         TrustEvaluator trustEvaluator = trustEvaluatorProvider.getIfAvailable();
         if (trustEvaluator == null) {
             trustEvaluator = NoopTrustEvaluator.INSTANCE;
+        }
+        TrustPolicyAdjuster trustPolicyAdjuster = trustPolicyAdjusterProvider.getIfAvailable();
+        if (trustPolicyAdjuster == null) {
+            trustPolicyAdjuster = NoopTrustPolicyAdjuster.INSTANCE;
         }
         IdentityResponseHook identityResponseHook = identityResponseHookProvider.getIfAvailable();
         if (identityResponseHook == null) {
@@ -470,6 +520,7 @@ public class SentinelAutoConfiguration {
             props.getMode().name(),
             identityContextResolver,
             trustEvaluator,
+            trustPolicyAdjuster,
             identityResponseHook
         );
     }

--- a/ai-sentinel-spring-boot-starter/src/main/java/io/aisentinel/autoconfigure/config/SentinelProperties.java
+++ b/ai-sentinel-spring-boot-starter/src/main/java/io/aisentinel/autoconfigure/config/SentinelProperties.java
@@ -81,6 +81,46 @@ public class SentinelProperties {
         /** Phase 2 — local behavioral trust baselines and evaluation (only when {@link #enabled} is true). */
         @Valid
         private Trust trust = new Trust();
+        /** Phase 3 — trust-aware escalation of {@link io.aisentinel.core.policy.EnforcementAction} (default off). */
+        @Valid
+        private TrustAwarePolicy trustAwarePolicy = new TrustAwarePolicy();
+    }
+
+    @Data
+    public static class TrustAwarePolicy {
+        /**
+         * When false (default), {@link io.aisentinel.core.policy.NoopTrustPolicyAdjuster} is used and anomaly policy
+         * alone drives enforcement.
+         */
+        private boolean enabled = false;
+        /** Path patterns: exact match, prefix plus {@code *}, or prefix ending with {@code /**} for subtree. Empty means no protected routes (no THROTTLE/BLOCK from trust on sensitive surfaces). */
+        private List<String> protectedEndpointPatterns = List.of();
+        /** Upper-case methods (e.g. POST); when empty, all methods match protected patterns. */
+        private List<String> httpMethods = List.of();
+        /** When true, trust bands apply only to authenticated, non-anonymous principals. */
+        private boolean authenticatedOnly = true;
+        /** Trust at or above this: no trust-based escalation. */
+        @DecimalMin("0.0")
+        @DecimalMax("1.0")
+        private double trustNoEffectMinimum = 0.80;
+        /** Trust at or above this (and below no-effect): at least MONITOR. */
+        @DecimalMin("0.0")
+        @DecimalMax("1.0")
+        private double trustMediumBandMinimum = 0.50;
+        /** Trust at or above this (and below medium): THROTTLE on protected routes else MONITOR. */
+        @DecimalMin("0.0")
+        @DecimalMax("1.0")
+        private double trustLowBandMinimum = 0.25;
+        /**
+         * When true, critical trust (below low band) on a protected route may escalate to BLOCK when
+         * {@link #requireMinRiskForTrustDeny} is satisfied or disabled.
+         */
+        private boolean denyOnCriticalTrustEnabled = false;
+        /** When true with deny, BLOCK requires {@link #minRiskScoreForTrustDeny} &lt;= anomaly score. */
+        private boolean requireMinRiskForTrustDeny = true;
+        @DecimalMin("0.0")
+        @DecimalMax("1.0")
+        private double minRiskScoreForTrustDeny = 0.40;
     }
 
     @Data

--- a/ai-sentinel-spring-boot-starter/src/test/java/io/aisentinel/autoconfigure/config/SentinelAutoConfigurationTest.java
+++ b/ai-sentinel-spring-boot-starter/src/test/java/io/aisentinel/autoconfigure/config/SentinelAutoConfigurationTest.java
@@ -16,6 +16,9 @@ import io.aisentinel.core.identity.spi.IdentityContextResolver;
 import io.aisentinel.core.identity.spi.NoopIdentityContextResolver;
 import io.aisentinel.core.identity.spi.NoopTrustEvaluator;
 import io.aisentinel.core.identity.spi.TrustEvaluator;
+import io.aisentinel.core.policy.DefaultTrustPolicyAdjuster;
+import io.aisentinel.core.policy.NoopTrustPolicyAdjuster;
+import io.aisentinel.core.policy.TrustPolicyAdjuster;
 import io.aisentinel.core.identity.trust.BehavioralIdentityTrustEvaluator;
 import io.aisentinel.core.model.RequestFeatures;
 import io.aisentinel.core.policy.EnforcementAction;
@@ -29,7 +32,12 @@ import io.aisentinel.autoconfigure.distributed.training.TrainingPublishStatus;
 import io.aisentinel.distributed.training.NoopTrainingCandidatePublisher;
 import io.aisentinel.distributed.training.TrainingCandidatePublisher;
 import io.aisentinel.distributed.throttle.ClusterThrottleStore;
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
 import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
 import org.junit.jupiter.api.io.TempDir;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.WebApplicationContextRunner;
@@ -107,6 +115,49 @@ class SentinelAutoConfigurationTest {
                 assertThat(context.getBean(IdentityContextResolver.class)).isInstanceOf(ServletIdentityContextResolver.class);
                 assertThat(context.getBean(TrustEvaluator.class)).isSameAs(NoopTrustEvaluator.INSTANCE);
             });
+    }
+
+    @Test
+    void trustAwarePolicyDisabledUsesNoopTrustPolicyAdjuster() {
+        contextRunner
+            .withPropertyValues("ai.sentinel.enabled=true")
+            .run(context -> assertThat(context.getBean(TrustPolicyAdjuster.class)).isSameAs(NoopTrustPolicyAdjuster.INSTANCE));
+    }
+
+    @Test
+    void trustAwarePolicyEnabledRegistersDefaultTrustPolicyAdjuster() {
+        contextRunner
+            .withPropertyValues(
+                "ai.sentinel.enabled=true",
+                "ai.sentinel.identity.trust-aware-policy.enabled=true",
+                "ai.sentinel.identity.trust-aware-policy.protected-endpoint-patterns=/api/sensitive/**")
+            .run(context ->
+                assertThat(context.getBean(TrustPolicyAdjuster.class)).isInstanceOf(DefaultTrustPolicyAdjuster.class));
+    }
+
+    @Test
+    void trustAwarePolicyEnabledWithIdentityDisabledLogsConfigurationWarning() {
+        Logger logger = (Logger) LoggerFactory.getLogger(SentinelAutoConfiguration.class);
+        ListAppender<ILoggingEvent> appender = new ListAppender<>();
+        appender.setContext(logger.getLoggerContext());
+        appender.start();
+        logger.addAppender(appender);
+        logger.setLevel(Level.WARN);
+        try {
+            contextRunner
+                .withPropertyValues(
+                    "ai.sentinel.enabled=true",
+                    "ai.sentinel.identity.enabled=false",
+                    "ai.sentinel.identity.trust-aware-policy.enabled=true",
+                    "ai.sentinel.identity.trust-aware-policy.protected-endpoint-patterns=/x/**")
+                .run(context ->
+                    assertThat(context.getBean(TrustPolicyAdjuster.class)).isInstanceOf(DefaultTrustPolicyAdjuster.class));
+        } finally {
+            logger.detachAppender(appender);
+            logger.setLevel(null);
+        }
+        assertThat(appender.list.stream().map(ILoggingEvent::getFormattedMessage))
+            .anyMatch(m -> m.contains("trust-aware policy has no effect"));
     }
 
     @Test


### PR DESCRIPTION
Adds post-policy trust-aware escalation via TrustPolicyAdjuster, wired through SentinelPipeline and the Spring Boot starter. Trust never relaxes anomaly policy (escalation-only), remains off by default, and adjuster failures stay fail-open. Includes a small hardening pass (subtree pattern root match, config warning, focused tests).