### PR TITLE
Phase 4: trust–anomaly fusion (default-off) + training score separation

### DIFF
--- a/ai-sentinel-core/src/main/java/io/aisentinel/core/SentinelPipeline.java
+++ b/ai-sentinel-core/src/main/java/io/aisentinel/core/SentinelPipeline.java
@@ -1,7 +1,6 @@
 package io.aisentinel.core;
 
 import io.aisentinel.core.enforcement.EnforcementHandler;
-import io.aisentinel.core.enforcement.EnforcementKeys;
 import io.aisentinel.core.enforcement.EnforcementScope;
 import io.aisentinel.core.feature.FeatureExtractor;
 import io.aisentinel.core.identity.IdentityContextKeys;
@@ -21,6 +20,10 @@ import io.aisentinel.core.metrics.SentinelMetrics;
 import io.aisentinel.core.runtime.StartupGrace;
 import io.aisentinel.core.scoring.AnomalyScorer;
 import io.aisentinel.core.scoring.CompositeScorer;
+import io.aisentinel.core.fusion.FusedRisk;
+import io.aisentinel.core.fusion.FusionContextKeys;
+import io.aisentinel.core.fusion.NoopRequestRiskFusion;
+import io.aisentinel.core.fusion.RequestRiskFusion;
 import io.aisentinel.core.telemetry.TelemetryEmitter;
 import io.aisentinel.core.telemetry.TelemetryEvent;
 import io.aisentinel.distributed.training.NoopTrainingCandidatePublisher;
@@ -56,13 +59,15 @@ public final class SentinelPipeline {
     private final IdentityContextResolver identityContextResolver;
     private final TrustEvaluator trustEvaluator;
     private final IdentityResponseHook identityResponseHook;
+    private final RequestRiskFusion riskFusion;
 
     public SentinelPipeline(FeatureExtractor featureExtractor, AnomalyScorer scorer, PolicyEngine policyEngine,
                             EnforcementHandler enforcementHandler, TelemetryEmitter telemetry, StartupGrace startupGrace,
                             SentinelMetrics metrics) {
         this(featureExtractor, scorer, null, policyEngine, enforcementHandler, telemetry, startupGrace, metrics,
             NoopTrainingCandidatePublisher.INSTANCE, EnforcementScope.IDENTITY_ENDPOINT, "default", "", "ENFORCE",
-            NoopIdentityContextResolver.INSTANCE, NoopTrustEvaluator.INSTANCE, NoopIdentityResponseHook.INSTANCE);
+            NoopIdentityContextResolver.INSTANCE, NoopTrustEvaluator.INSTANCE, NoopIdentityResponseHook.INSTANCE,
+            NoopRequestRiskFusion.INSTANCE);
     }
 
     public SentinelPipeline(FeatureExtractor featureExtractor,
@@ -80,7 +85,8 @@ public final class SentinelPipeline {
                             String sentinelModeName,
                             IdentityContextResolver identityContextResolver,
                             TrustEvaluator trustEvaluator,
-                            IdentityResponseHook identityResponseHook) {
+                            IdentityResponseHook identityResponseHook,
+                            RequestRiskFusion riskFusion) {
         this.featureExtractor = featureExtractor;
         this.scorer = scorer;
         this.compositeScorerOrNull = compositeScorerOrNull;
@@ -99,6 +105,7 @@ public final class SentinelPipeline {
         this.identityContextResolver = identityContextResolver != null ? identityContextResolver : NoopIdentityContextResolver.INSTANCE;
         this.trustEvaluator = trustEvaluator != null ? trustEvaluator : NoopTrustEvaluator.INSTANCE;
         this.identityResponseHook = identityResponseHook != null ? identityResponseHook : NoopIdentityResponseHook.INSTANCE;
+        this.riskFusion = riskFusion != null ? riskFusion : NoopRequestRiskFusion.INSTANCE;
     }
 
     /**
@@ -163,9 +170,27 @@ public final class SentinelPipeline {
             }
             double score = clampScore(rawScore);
 
-            EnforcementAction action = policyEngine.evaluate(score, features, features.endpoint());
+            double policyScore = score;
+            if (riskFusion.enabled()) {
+                IdentityContext identityForFusion = ctx.get(IdentityContextKeys.IDENTITY_CONTEXT, IdentityContext.class);
+                if (identityForFusion != null) {
+                    try {
+                        double trust = identityForFusion.trust().value();
+                        if (!Double.isNaN(trust)) {
+                            FusedRisk fused = riskFusion.fuse(score, trust);
+                            policyScore = fused.fusedScore();
+                            ctx.put(FusionContextKeys.FUSED_RISK, fused);
+                        }
+                    } catch (Exception e) {
+                        log.debug("Risk fusion failed for {}: {}", features.endpoint(), e.getMessage());
+                        metrics.recordFailOpen();
+                    }
+                }
+            }
 
-            telemetry.emit(TelemetryEvent.threatScored(identityHash, features.endpoint(), score));
+            EnforcementAction action = policyEngine.evaluate(policyScore, features, features.endpoint());
+
+            telemetry.emit(TelemetryEvent.threatScored(identityHash, features.endpoint(), policyScore));
             if (score > 0.5) {
                 telemetry.emit(TelemetryEvent.anomalyDetected(identityHash, features.endpoint(), score));
             }
@@ -180,7 +205,7 @@ public final class SentinelPipeline {
             metrics.recordPolicyAction(action);
             boolean proceed = enforcementHandler.apply(action, request, response, identityHash, features.endpoint());
 
-            offerTrainingCandidate(features, identityHash, action, score, proceed, startupGraceActive);
+            offerTrainingCandidate(features, identityHash, action, score, proceed, startupGraceActive, ctx);
 
             returnValue = proceed;
             return returnValue;
@@ -197,7 +222,10 @@ public final class SentinelPipeline {
     }
 
     private void offerTrainingCandidate(RequestFeatures features, String identityHash, EnforcementAction action,
-                                        double compositeScore, boolean requestProceeded, boolean startupGraceActive) {
+                                        double rawAnomalyScoreClamped,
+                                        boolean requestProceeded,
+                                        boolean startupGraceActive,
+                                        RequestContext ctx) {
         try {
             Double statisticalScore = null;
             Double isolationForestScore = null;
@@ -209,11 +237,13 @@ public final class SentinelPipeline {
                     isolationForestScore = snap.isolationForest();
                 }
             }
-            String enforcementKey = EnforcementKeys.enforcementKey(enforcementScope, identityHash, features.endpoint());
+            FusedRisk fusedRisk = ctx.get(FusionContextKeys.FUSED_RISK, FusedRisk.class);
+            Double trustForTraining = fusedRisk != null ? fusedRisk.trustScore() : null;
+            Double fusedForTraining = fusedRisk != null ? fusedRisk.fusedScore() : null;
             trainingCandidatePublisher.publish(new TrainingCandidatePublishRequest(
                 features,
                 action,
-                compositeScore,
+                rawAnomalyScoreClamped,
                 statisticalScore,
                 isolationForestScore,
                 enforcementScope,
@@ -221,7 +251,9 @@ public final class SentinelPipeline {
                 trainingNodeId,
                 sentinelModeName,
                 requestProceeded,
-                startupGraceActive
+                startupGraceActive,
+                trustForTraining,
+                fusedForTraining
             ));
         } catch (Exception e) {
             log.debug("Training candidate publisher failed: {}", e.toString());
@@ -229,7 +261,11 @@ public final class SentinelPipeline {
         }
     }
 
-    /** Prevents NaN or out-of-range scores from causing policy bypass; treat NaN as high risk. */
+    /**
+     * Prevents NaN or out-of-range scores from causing policy bypass; treat NaN as high risk.
+     * Fusion runs only after this clamp, so {@link io.aisentinel.core.fusion.DeterministicRequestRiskFusion}'s internal
+     * {@code clamp01} treating NaN as 0 is not used for raw scorer output on the request path.
+     */
     private static double clampScore(double score) {
         if (Double.isNaN(score) || score < 0) return 1.0;
         return Math.min(1.0, score);

--- a/ai-sentinel-core/src/main/java/io/aisentinel/core/fusion/DeterministicRequestRiskFusion.java
+++ b/ai-sentinel-core/src/main/java/io/aisentinel/core/fusion/DeterministicRequestRiskFusion.java
@@ -1,0 +1,54 @@
+package io.aisentinel.core.fusion;
+
+import java.util.Locale;
+
+/**
+ * Bounded deterministic fusion: low trust amplifies anomaly; high trust slightly dampens; small additive bump from
+ * distrust so very low trust still elevates low anomaly scores. Does not replace the raw anomaly scorer.
+ */
+public final class DeterministicRequestRiskFusion implements RequestRiskFusion {
+
+    private final double strength;
+
+    public DeterministicRequestRiskFusion(double strength) {
+        if (Double.isNaN(strength) || Double.isInfinite(strength)) {
+            this.strength = 0.0;
+        } else {
+            this.strength = Math.max(0.0, Math.min(1.0, strength));
+        }
+    }
+
+    @Override
+    public boolean enabled() {
+        return true;
+    }
+
+    @Override
+    public FusedRisk fuse(double anomalyScoreClamped, double trustScoreClamped) {
+        double a = clamp01(anomalyScoreClamped);
+        double t = clamp01(trustScoreClamped);
+        double k = strength;
+        double distrust = 1.0 - t;
+        double mult = 1.0 + k * distrust;
+        double dampen = 1.0 - 0.2 * k * t;
+        double additive = 0.15 * k * distrust;
+        double raw = a * mult * dampen + additive;
+        double fused = Math.min(1.0, raw);
+        String detail = String.format(Locale.ROOT,
+            "fusion:anomaly=%.4f;trust=%.4f;strength=%.4f;distrust=%.4f;mult=%.4f;dampen=%.4f;additive=%.4f;fused=%.4f",
+            a, t, k, distrust, mult, dampen, additive, fused);
+        return new FusedRisk(a, t, fused, detail);
+    }
+
+    /**
+     * Defensive clamp for inputs to {@link #fuse}; NaN maps to 0 so fusion stays bounded.
+     * On the request path, anomaly and trust are already finite: {@link io.aisentinel.core.SentinelPipeline} clamps the
+     * scorer first, and trust comes from {@link io.aisentinel.core.identity.model.TrustScore}.
+     */
+    private static double clamp01(double v) {
+        if (Double.isNaN(v) || v < 0) {
+            return 0.0;
+        }
+        return Math.min(1.0, v);
+    }
+}

--- a/ai-sentinel-core/src/main/java/io/aisentinel/core/fusion/FusedRisk.java
+++ b/ai-sentinel-core/src/main/java/io/aisentinel/core/fusion/FusedRisk.java
@@ -1,0 +1,11 @@
+package io.aisentinel.core.fusion;
+
+/**
+ * Phase 4 — anomaly + trust fused into a single risk input for {@link io.aisentinel.core.policy.PolicyEngine}.
+ *
+ * @param anomalyScore clamped anomaly score in {@code [0,1]} used as fusion input
+ * @param trustScore     trust in {@code [0,1]} used as fusion input (higher = more trusted)
+ * @param fusedScore     bounded fused value passed to policy
+ * @param fusionDetail   human-readable breakdown for operators / hooks
+ */
+public record FusedRisk(double anomalyScore, double trustScore, double fusedScore, String fusionDetail) {}

--- a/ai-sentinel-core/src/main/java/io/aisentinel/core/fusion/FusionContextKeys.java
+++ b/ai-sentinel-core/src/main/java/io/aisentinel/core/fusion/FusionContextKeys.java
@@ -1,0 +1,12 @@
+package io.aisentinel.core.fusion;
+
+/**
+ * Keys for fusion outputs on {@link io.aisentinel.core.model.RequestContext}.
+ */
+public final class FusionContextKeys {
+
+    /** Latest {@link FusedRisk} for this request when fusion ran; absent when fusion is off or skipped. */
+    public static final String FUSED_RISK = "io.aisentinel.fusion.FUSED_RISK";
+
+    private FusionContextKeys() {}
+}

--- a/ai-sentinel-core/src/main/java/io/aisentinel/core/fusion/NoopRequestRiskFusion.java
+++ b/ai-sentinel-core/src/main/java/io/aisentinel/core/fusion/NoopRequestRiskFusion.java
@@ -1,0 +1,18 @@
+package io.aisentinel.core.fusion;
+
+/**
+ * Fusion disabled: policy input remains the anomaly score; {@link #fuse} is only used if mis-invoked (pass-through).
+ */
+public enum NoopRequestRiskFusion implements RequestRiskFusion {
+    INSTANCE;
+
+    @Override
+    public boolean enabled() {
+        return false;
+    }
+
+    @Override
+    public FusedRisk fuse(double anomalyScoreClamped, double trustScoreClamped) {
+        return new FusedRisk(anomalyScoreClamped, trustScoreClamped, anomalyScoreClamped, "fusion=disabled");
+    }
+}

--- a/ai-sentinel-core/src/main/java/io/aisentinel/core/fusion/RequestRiskFusion.java
+++ b/ai-sentinel-core/src/main/java/io/aisentinel/core/fusion/RequestRiskFusion.java
@@ -1,0 +1,16 @@
+package io.aisentinel.core.fusion;
+
+/**
+ * Phase 4 — combines clamped anomaly score with trust into a single policy input.
+ */
+public interface RequestRiskFusion {
+
+    /** When false, pipeline must not apply fusion (policy uses anomaly score only). */
+    boolean enabled();
+
+    /**
+     * Deterministic fusion of anomaly and trust into {@link FusedRisk#fusedScore()}.
+     * Implementations should be side-effect free and bounded to {@code [0,1]} for {@code fusedScore}.
+     */
+    FusedRisk fuse(double anomalyScoreClamped, double trustScoreClamped);
+}

--- a/ai-sentinel-core/src/main/java/io/aisentinel/distributed/training/TrainingCandidatePublishRequest.java
+++ b/ai-sentinel-core/src/main/java/io/aisentinel/distributed/training/TrainingCandidatePublishRequest.java
@@ -7,6 +7,10 @@ import io.aisentinel.core.policy.EnforcementAction;
 /**
  * Inputs for training candidate export, captured on the request thread after policy and enforcement.
  * The publisher must copy feature arrays before handing off to another thread.
+ * <p>
+ * {@link #compositeScore()} is the <strong>raw clamped anomaly</strong> (post-scorer, pre-fusion). When trust–anomaly
+ * fusion ran, {@link #trustScore()} and {@link #fusedPolicyScore()} carry the trust input and fused value used for
+ * policy; both are null if fusion did not apply for that request.
  */
 public final class TrainingCandidatePublishRequest {
 
@@ -21,6 +25,8 @@ public final class TrainingCandidatePublishRequest {
     private final String sentinelMode;
     private final boolean requestProceeded;
     private final boolean startupGraceActive;
+    private final Double trustScore;
+    private final Double fusedPolicyScore;
 
     public TrainingCandidatePublishRequest(
         RequestFeatures features,
@@ -33,7 +39,9 @@ public final class TrainingCandidatePublishRequest {
         String nodeId,
         String sentinelMode,
         boolean requestProceeded,
-        boolean startupGraceActive
+        boolean startupGraceActive,
+        Double trustScore,
+        Double fusedPolicyScore
     ) {
         this.features = features;
         this.policyAction = policyAction;
@@ -46,6 +54,8 @@ public final class TrainingCandidatePublishRequest {
         this.sentinelMode = sentinelMode != null ? sentinelMode : "ENFORCE";
         this.requestProceeded = requestProceeded;
         this.startupGraceActive = startupGraceActive;
+        this.trustScore = trustScore;
+        this.fusedPolicyScore = fusedPolicyScore;
     }
 
     public RequestFeatures features() {
@@ -90,5 +100,15 @@ public final class TrainingCandidatePublishRequest {
 
     public boolean startupGraceActive() {
         return startupGraceActive;
+    }
+
+    /** Trust value used when fusion produced {@link #fusedPolicyScore()}; otherwise {@code null}. */
+    public Double trustScore() {
+        return trustScore;
+    }
+
+    /** Fused score passed to policy when fusion applied; otherwise {@code null}. */
+    public Double fusedPolicyScore() {
+        return fusedPolicyScore;
     }
 }

--- a/ai-sentinel-core/src/main/java/io/aisentinel/distributed/training/TrainingCandidateRecord.java
+++ b/ai-sentinel-core/src/main/java/io/aisentinel/distributed/training/TrainingCandidateRecord.java
@@ -10,7 +10,12 @@ import java.util.Objects;
 public final class TrainingCandidateRecord {
 
     /** Schema 2: endpoint/enforcement key as hashes; eventId for deduplication. */
-    public static final int CURRENT_SCHEMA_VERSION = 2;
+    public static final int SCHEMA_VERSION_2 = 2;
+    /**
+     * Schema 3: same as 2 plus optional {@link #trustScore()} / {@link #fusedPolicyScore()} when fusion separates
+     * signals from {@link #compositeScore()} (raw clamped anomaly for training).
+     */
+    public static final int CURRENT_SCHEMA_VERSION = 3;
 
     private static final int MAX_TENANT = 128;
     private static final int MAX_NODE = 128;
@@ -32,7 +37,10 @@ public final class TrainingCandidateRecord {
     private final double[] statisticalFeatures;
     private final Double statisticalScore;
     private final Double isolationForestScore;
+    /** Raw clamped anomaly (pre-fusion); not the fused policy input when fusion fields are set. */
     private final double compositeScore;
+    private final Double trustScore;
+    private final Double fusedPolicyScore;
     private final String policyAction;
     private final String sentinelMode;
     private final boolean requestProceeded;
@@ -52,6 +60,8 @@ public final class TrainingCandidateRecord {
         Double statisticalScore,
         Double isolationForestScore,
         double compositeScore,
+        Double trustScore,
+        Double fusedPolicyScore,
         String policyAction,
         String sentinelMode,
         boolean requestProceeded,
@@ -70,6 +80,8 @@ public final class TrainingCandidateRecord {
         this.statisticalScore = statisticalScore;
         this.isolationForestScore = isolationForestScore;
         this.compositeScore = clampUnit(compositeScore);
+        this.trustScore = trustScore;
+        this.fusedPolicyScore = fusedPolicyScore != null ? clampUnitNullable(fusedPolicyScore) : null;
         this.policyAction = truncate(policyAction, MAX_ACTION);
         this.sentinelMode = truncate(sentinelMode, MAX_MODE);
         this.requestProceeded = requestProceeded;
@@ -105,6 +117,13 @@ public final class TrainingCandidateRecord {
             return 0.0;
         }
         return Math.min(1.0, v);
+    }
+
+    private static Double clampUnitNullable(Double v) {
+        if (v == null) {
+            return null;
+        }
+        return clampUnit(v);
     }
 
     public int schemaVersion() {
@@ -159,6 +178,14 @@ public final class TrainingCandidateRecord {
         return compositeScore;
     }
 
+    public Double trustScore() {
+        return trustScore;
+    }
+
+    public Double fusedPolicyScore() {
+        return fusedPolicyScore;
+    }
+
     public String policyAction() {
         return policyAction;
     }
@@ -182,6 +209,8 @@ public final class TrainingCandidateRecord {
         return schemaVersion == that.schemaVersion
             && observedAtEpochMillis == that.observedAtEpochMillis
             && Double.compare(that.compositeScore, compositeScore) == 0
+            && Objects.equals(trustScore, that.trustScore)
+            && Objects.equals(fusedPolicyScore, that.fusedPolicyScore)
             && requestProceeded == that.requestProceeded
             && startupGraceActive == that.startupGraceActive
             && Objects.equals(eventId, that.eventId)
@@ -203,6 +232,6 @@ public final class TrainingCandidateRecord {
         return Objects.hash(schemaVersion, eventId, tenantId, nodeId, identityHash, endpointSha256Hex,
             enforcementKeySha256Hex, observedAtEpochMillis, Arrays.hashCode(isolationForestFeatures),
             Arrays.hashCode(statisticalFeatures), statisticalScore, isolationForestScore, compositeScore,
-            policyAction, sentinelMode, requestProceeded, startupGraceActive);
+            trustScore, fusedPolicyScore, policyAction, sentinelMode, requestProceeded, startupGraceActive);
     }
 }

--- a/ai-sentinel-core/src/test/java/io/aisentinel/core/SentinelPipelineFusionTest.java
+++ b/ai-sentinel-core/src/test/java/io/aisentinel/core/SentinelPipelineFusionTest.java
@@ -1,0 +1,265 @@
+package io.aisentinel.core;
+
+import io.aisentinel.core.enforcement.EnforcementHandler;
+import io.aisentinel.core.enforcement.EnforcementScope;
+import io.aisentinel.core.feature.FeatureExtractor;
+import io.aisentinel.core.fusion.DeterministicRequestRiskFusion;
+import io.aisentinel.core.fusion.FusedRisk;
+import io.aisentinel.core.fusion.FusionContextKeys;
+import io.aisentinel.core.fusion.NoopRequestRiskFusion;
+import io.aisentinel.core.fusion.RequestRiskFusion;
+import io.aisentinel.core.identity.IdentityContextKeys;
+import io.aisentinel.core.identity.model.AuthenticationContext;
+import io.aisentinel.core.identity.model.IdentityContext;
+import io.aisentinel.core.identity.model.IdentityRiskSignals;
+import io.aisentinel.core.identity.model.SessionContext;
+import io.aisentinel.core.identity.model.TrustScore;
+import io.aisentinel.core.identity.spi.IdentityContextResolver;
+import io.aisentinel.core.identity.spi.IdentityResponseHook;
+import io.aisentinel.core.identity.spi.NoopIdentityContextResolver;
+import io.aisentinel.core.identity.spi.NoopIdentityResponseHook;
+import io.aisentinel.core.identity.spi.NoopTrustEvaluator;
+import io.aisentinel.core.model.RequestContext;
+import io.aisentinel.core.model.RequestFeatures;
+import io.aisentinel.core.metrics.SentinelMetrics;
+import io.aisentinel.core.policy.EnforcementAction;
+import io.aisentinel.core.policy.PolicyEngine;
+import io.aisentinel.core.policy.ThresholdPolicyEngine;
+import io.aisentinel.core.runtime.StartupGrace;
+import io.aisentinel.core.scoring.AnomalyScorer;
+import io.aisentinel.core.telemetry.TelemetryEmitter;
+import io.aisentinel.distributed.training.NoopTrainingCandidatePublisher;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.anyDouble;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class SentinelPipelineFusionTest {
+
+    private static RequestFeatures features() {
+        return RequestFeatures.builder()
+            .identityHash("h").endpoint("/api").timestampMillis(0)
+            .requestsPerWindow(1).endpointEntropy(0).tokenAgeSeconds(60)
+            .parameterCount(0).payloadSizeBytes(0).headerFingerprintHash(0).ipBucket(0).build();
+    }
+
+    private static SentinelPipeline pipeline(IdentityContextResolver resolver,
+                                             RequestRiskFusion fusion,
+                                             PolicyEngine policy,
+                                             AnomalyScorer scorer,
+                                             IdentityResponseHook hook) {
+        FeatureExtractor extractor = mock(FeatureExtractor.class);
+        when(extractor.extract(any(), eq("h"), any(RequestContext.class))).thenReturn(features());
+        EnforcementHandler handler = mock(EnforcementHandler.class);
+        when(handler.isQuarantined(anyString(), anyString())).thenReturn(false);
+        when(handler.apply(any(), any(), any(), eq("h"), eq("/api"))).thenReturn(true);
+        return new SentinelPipeline(
+            extractor,
+            scorer,
+            null,
+            policy,
+            handler,
+            mock(TelemetryEmitter.class),
+            StartupGrace.NEVER,
+            SentinelMetrics.NOOP,
+            NoopTrainingCandidatePublisher.INSTANCE,
+            EnforcementScope.IDENTITY_ENDPOINT,
+            "default",
+            "",
+            "ENFORCE",
+            resolver,
+            NoopTrustEvaluator.INSTANCE,
+            hook,
+            fusion
+        );
+    }
+
+    @Test
+    void fusionDisabledPassesAnomalyScoreToPolicyUnchanged() throws Exception {
+        IdentityContextResolver resolver = (req, hash, ctx) -> {
+            IdentityContext ic = new IdentityContext(
+                AuthenticationContext.ofPrincipal("u"),
+                SessionContext.none(),
+                new TrustScore(0.05, "low"),
+                IdentityRiskSignals.empty());
+            ctx.put(IdentityContextKeys.IDENTITY_CONTEXT, ic);
+        };
+        PolicyEngine policy = mock(PolicyEngine.class);
+        when(policy.evaluate(anyDouble(), any(), eq("/api"))).thenReturn(EnforcementAction.ALLOW);
+        AnomalyScorer scorer = mock(AnomalyScorer.class);
+        when(scorer.score(any())).thenReturn(0.35);
+        SentinelPipeline p = pipeline(resolver, NoopRequestRiskFusion.INSTANCE, policy, scorer, NoopIdentityResponseHook.INSTANCE);
+        p.process(mock(HttpServletRequest.class), mock(HttpServletResponse.class), "h");
+        ArgumentCaptor<Double> scoreCap = ArgumentCaptor.forClass(Double.class);
+        verify(policy).evaluate(scoreCap.capture(), any(), eq("/api"));
+        assertThat(scoreCap.getValue()).isEqualTo(0.35);
+    }
+
+    @Test
+    void fusionEnabledWithoutIdentityContextBehavesLikeFusionOff() throws Exception {
+        PolicyEngine policy = mock(PolicyEngine.class);
+        when(policy.evaluate(anyDouble(), any(), eq("/api"))).thenReturn(EnforcementAction.ALLOW);
+        AnomalyScorer scorer = mock(AnomalyScorer.class);
+        when(scorer.score(any())).thenReturn(0.35);
+        SentinelPipeline p = pipeline(
+            NoopIdentityContextResolver.INSTANCE,
+            new DeterministicRequestRiskFusion(0.9),
+            policy,
+            scorer,
+            NoopIdentityResponseHook.INSTANCE);
+        p.process(mock(HttpServletRequest.class), mock(HttpServletResponse.class), "h");
+        ArgumentCaptor<Double> scoreCap = ArgumentCaptor.forClass(Double.class);
+        verify(policy).evaluate(scoreCap.capture(), any(), eq("/api"));
+        assertThat(scoreCap.getValue()).isEqualTo(0.35);
+    }
+
+    @Test
+    void lowTrustElevatesPolicyScoreVersusFusionDisabled() throws Exception {
+        IdentityContextResolver resolver = (req, hash, ctx) -> {
+            IdentityContext ic = new IdentityContext(
+                AuthenticationContext.ofPrincipal("u"),
+                SessionContext.none(),
+                new TrustScore(0.05, "low"),
+                IdentityRiskSignals.empty());
+            ctx.put(IdentityContextKeys.IDENTITY_CONTEXT, ic);
+        };
+        PolicyEngine policyNoFusion = mock(PolicyEngine.class);
+        when(policyNoFusion.evaluate(anyDouble(), any(), eq("/api"))).thenReturn(EnforcementAction.MONITOR);
+        AnomalyScorer scorer = mock(AnomalyScorer.class);
+        when(scorer.score(any())).thenReturn(0.35);
+        SentinelPipeline noFusion = pipeline(resolver, NoopRequestRiskFusion.INSTANCE, policyNoFusion, scorer, NoopIdentityResponseHook.INSTANCE);
+        noFusion.process(mock(HttpServletRequest.class), mock(HttpServletResponse.class), "h");
+        ArgumentCaptor<Double> capNo = ArgumentCaptor.forClass(Double.class);
+        verify(policyNoFusion).evaluate(capNo.capture(), any(), eq("/api"));
+        assertThat(capNo.getValue()).isEqualTo(0.35);
+
+        PolicyEngine policyFused = new ThresholdPolicyEngine();
+        EnforcementHandler handler = mock(EnforcementHandler.class);
+        when(handler.isQuarantined(anyString(), anyString())).thenReturn(false);
+        when(handler.apply(any(), any(), any(), eq("h"), eq("/api"))).thenReturn(true);
+        FeatureExtractor extractor = mock(FeatureExtractor.class);
+        when(extractor.extract(any(), eq("h"), any(RequestContext.class))).thenReturn(features());
+        SentinelPipeline fusedPipeline = new SentinelPipeline(
+            extractor,
+            scorer,
+            null,
+            policyFused,
+            handler,
+            mock(TelemetryEmitter.class),
+            StartupGrace.NEVER,
+            SentinelMetrics.NOOP,
+            NoopTrainingCandidatePublisher.INSTANCE,
+            EnforcementScope.IDENTITY_ENDPOINT,
+            "default",
+            "",
+            "ENFORCE",
+            resolver,
+            NoopTrustEvaluator.INSTANCE,
+            NoopIdentityResponseHook.INSTANCE,
+            new DeterministicRequestRiskFusion(0.9));
+        assertThat(fusedPipeline.process(mock(HttpServletRequest.class), mock(HttpServletResponse.class), "h")).isTrue();
+        verify(handler).apply(argThat(a -> a != EnforcementAction.ALLOW && a != EnforcementAction.MONITOR),
+            any(), any(), eq("h"), eq("/api"));
+    }
+
+    @Test
+    void fusionFailureIsFailOpenAndUsesAnomalyScore() throws Exception {
+        IdentityContextResolver resolver = (req, hash, ctx) -> {
+            IdentityContext ic = new IdentityContext(
+                AuthenticationContext.ofPrincipal("u"),
+                SessionContext.none(),
+                new TrustScore(0.1, "t"),
+                IdentityRiskSignals.empty());
+            ctx.put(IdentityContextKeys.IDENTITY_CONTEXT, ic);
+        };
+        RequestRiskFusion throwing = new RequestRiskFusion() {
+            @Override
+            public boolean enabled() {
+                return true;
+            }
+
+            @Override
+            public FusedRisk fuse(double anomalyScoreClamped, double trustScoreClamped) {
+                throw new RuntimeException("fusion boom");
+            }
+        };
+        AtomicInteger failOpen = new AtomicInteger();
+        SentinelMetrics metrics = new SentinelMetrics() {
+            @Override
+            public void recordFailOpen() {
+                failOpen.incrementAndGet();
+            }
+        };
+        FeatureExtractor extractor = mock(FeatureExtractor.class);
+        when(extractor.extract(any(), eq("h"), any(RequestContext.class))).thenReturn(features());
+        AnomalyScorer scorer = mock(AnomalyScorer.class);
+        when(scorer.score(any())).thenReturn(0.22);
+        PolicyEngine policy = mock(PolicyEngine.class);
+        when(policy.evaluate(anyDouble(), any(), eq("/api"))).thenReturn(EnforcementAction.ALLOW);
+        EnforcementHandler handler = mock(EnforcementHandler.class);
+        when(handler.isQuarantined(anyString(), anyString())).thenReturn(false);
+        when(handler.apply(eq(EnforcementAction.ALLOW), any(), any(), eq("h"), eq("/api"))).thenReturn(true);
+        SentinelPipeline p = new SentinelPipeline(
+            extractor,
+            scorer,
+            null,
+            policy,
+            handler,
+            mock(TelemetryEmitter.class),
+            StartupGrace.NEVER,
+            metrics,
+            NoopTrainingCandidatePublisher.INSTANCE,
+            EnforcementScope.IDENTITY_ENDPOINT,
+            "default",
+            "",
+            "ENFORCE",
+            resolver,
+            NoopTrustEvaluator.INSTANCE,
+            NoopIdentityResponseHook.INSTANCE,
+            throwing);
+        assertThat(p.process(mock(HttpServletRequest.class), mock(HttpServletResponse.class), "h")).isTrue();
+        assertThat(failOpen.get()).isEqualTo(1);
+        ArgumentCaptor<Double> cap = ArgumentCaptor.forClass(Double.class);
+        verify(policy).evaluate(cap.capture(), any(), eq("/api"));
+        assertThat(cap.getValue()).isEqualTo(0.22);
+    }
+
+    @Test
+    void fusionStoresFusedRiskOnContextForHooks() throws Exception {
+        AtomicReference<RequestContext> ctxSeen = new AtomicReference<>();
+        IdentityResponseHook hook = (req, res, hash, feats, ctx, ok) -> ctxSeen.set(ctx);
+        IdentityContextResolver resolver = (req, hash, ctx) -> {
+            IdentityContext ic = new IdentityContext(
+                AuthenticationContext.ofPrincipal("u"),
+                SessionContext.none(),
+                new TrustScore(0.5, "m"),
+                IdentityRiskSignals.empty());
+            ctx.put(IdentityContextKeys.IDENTITY_CONTEXT, ic);
+        };
+        PolicyEngine policy = mock(PolicyEngine.class);
+        when(policy.evaluate(anyDouble(), any(), eq("/api"))).thenReturn(EnforcementAction.ALLOW);
+        AnomalyScorer scorer = mock(AnomalyScorer.class);
+        when(scorer.score(any())).thenReturn(0.3);
+        SentinelPipeline p = pipeline(resolver, new DeterministicRequestRiskFusion(0.4), policy, scorer, hook);
+        p.process(mock(HttpServletRequest.class), mock(HttpServletResponse.class), "h");
+        FusedRisk fr = ctxSeen.get().get(FusionContextKeys.FUSED_RISK, FusedRisk.class);
+        assertThat(fr).isNotNull();
+        assertThat(fr.anomalyScore()).isEqualTo(0.3);
+        assertThat(fr.trustScore()).isEqualTo(0.5);
+        assertThat(fr.fusedScore()).isBetween(0.0, 1.0);
+        assertThat(fr.fusionDetail()).startsWith("fusion:anomaly=");
+    }
+}

--- a/ai-sentinel-core/src/test/java/io/aisentinel/core/SentinelPipelineIdentityFailOpenTest.java
+++ b/ai-sentinel-core/src/test/java/io/aisentinel/core/SentinelPipelineIdentityFailOpenTest.java
@@ -23,6 +23,7 @@ import io.aisentinel.core.runtime.StartupGrace;
 import io.aisentinel.core.scoring.AnomalyScorer;
 import io.aisentinel.core.telemetry.TelemetryEmitter;
 import io.aisentinel.distributed.training.NoopTrainingCandidatePublisher;
+import io.aisentinel.core.fusion.NoopRequestRiskFusion;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.junit.jupiter.api.Test;
@@ -89,7 +90,8 @@ class SentinelPipelineIdentityFailOpenTest {
             "ENFORCE",
             badResolver,
             NoopTrustEvaluator.INSTANCE,
-            NoopIdentityResponseHook.INSTANCE
+            NoopIdentityResponseHook.INSTANCE,
+            NoopRequestRiskFusion.INSTANCE
         );
 
         HttpServletRequest request = mock(HttpServletRequest.class);
@@ -149,7 +151,8 @@ class SentinelPipelineIdentityFailOpenTest {
             "ENFORCE",
             resolver,
             badTrust,
-            NoopIdentityResponseHook.INSTANCE
+            NoopIdentityResponseHook.INSTANCE,
+            NoopRequestRiskFusion.INSTANCE
         );
 
         HttpServletRequest request = mock(HttpServletRequest.class);

--- a/ai-sentinel-core/src/test/java/io/aisentinel/core/SentinelPipelineTrainingPublishTest.java
+++ b/ai-sentinel-core/src/test/java/io/aisentinel/core/SentinelPipelineTrainingPublishTest.java
@@ -11,6 +11,7 @@ import io.aisentinel.core.policy.PolicyEngine;
 import io.aisentinel.core.runtime.StartupGrace;
 import io.aisentinel.core.scoring.CompositeScorer;
 import io.aisentinel.core.identity.spi.NoopIdentityContextResolver;
+import io.aisentinel.core.fusion.NoopRequestRiskFusion;
 import io.aisentinel.core.identity.spi.NoopIdentityResponseHook;
 import io.aisentinel.core.identity.spi.NoopTrustEvaluator;
 import io.aisentinel.core.telemetry.TelemetryEmitter;
@@ -71,7 +72,8 @@ class SentinelPipelineTrainingPublishTest {
             "ENFORCE",
             NoopIdentityContextResolver.INSTANCE,
             NoopTrustEvaluator.INSTANCE,
-            NoopIdentityResponseHook.INSTANCE
+            NoopIdentityResponseHook.INSTANCE,
+            NoopRequestRiskFusion.INSTANCE
         );
 
         HttpServletRequest request = mock(HttpServletRequest.class);

--- a/ai-sentinel-core/src/test/java/io/aisentinel/core/fusion/DeterministicRequestRiskFusionTest.java
+++ b/ai-sentinel-core/src/test/java/io/aisentinel/core/fusion/DeterministicRequestRiskFusionTest.java
@@ -1,0 +1,84 @@
+package io.aisentinel.core.fusion;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DeterministicRequestRiskFusionTest {
+
+    @Test
+    void highTrustAndMediumAnomalyReducesFusedBelowAnomaly() {
+        DeterministicRequestRiskFusion f = new DeterministicRequestRiskFusion(0.5);
+        FusedRisk r = f.fuse(0.4, 0.98);
+        assertThat(r.fusedScore()).isLessThan(0.4);
+        assertThat(r.anomalyScore()).isEqualTo(0.4);
+        assertThat(r.trustScore()).isEqualTo(0.98);
+    }
+
+    @Test
+    void lowTrustAndMediumAnomalyIncreasesFused() {
+        DeterministicRequestRiskFusion f = new DeterministicRequestRiskFusion(0.9);
+        FusedRisk r = f.fuse(0.35, 0.05);
+        assertThat(r.fusedScore()).isGreaterThan(0.35);
+    }
+
+    @Test
+    void veryLowTrustAndLowAnomalyStillElevatesVersusAnomalyAlone() {
+        DeterministicRequestRiskFusion f = new DeterministicRequestRiskFusion(0.5);
+        FusedRisk r = f.fuse(0.1, 0.05);
+        assertThat(r.fusedScore()).isGreaterThan(0.1);
+    }
+
+    @Test
+    void highAnomalyAndHighTrustStaysHigh() {
+        DeterministicRequestRiskFusion f = new DeterministicRequestRiskFusion(0.9);
+        FusedRisk r = f.fuse(0.95, 0.95);
+        assertThat(r.fusedScore()).isGreaterThanOrEqualTo(0.8);
+    }
+
+    @Test
+    void explainabilityDetailIncludesComponents() {
+        DeterministicRequestRiskFusion f = new DeterministicRequestRiskFusion(0.35);
+        FusedRisk r = f.fuse(0.25, 0.5);
+        assertThat(r.fusionDetail())
+            .contains("fusion:anomaly=")
+            .contains("trust=")
+            .contains("fused=");
+    }
+
+    @Test
+    void invalidStrengthBecomesClamped() {
+        DeterministicRequestRiskFusion f = new DeterministicRequestRiskFusion(Double.NaN);
+        FusedRisk r = f.fuse(0.3, 0.3);
+        assertThat(r.fusionDetail()).contains("strength=0.0000");
+    }
+
+    @Test
+    void zeroAnomalyAndZeroTrustUsesAdditiveDistrustFloor() {
+        DeterministicRequestRiskFusion f = new DeterministicRequestRiskFusion(0.35);
+        FusedRisk r = f.fuse(0.0, 0.0);
+        double k = 0.35;
+        double expectedAdditive = 0.15 * k * 1.0;
+        assertThat(r.fusedScore()).isEqualTo(expectedAdditive);
+        assertThat(r.anomalyScore()).isZero();
+        assertThat(r.trustScore()).isZero();
+    }
+
+    @Test
+    void zeroStrengthPassesThroughAnomalyExactly() {
+        DeterministicRequestRiskFusion f = new DeterministicRequestRiskFusion(0.0);
+        FusedRisk r = f.fuse(0.42, 0.11);
+        assertThat(r.fusedScore()).isEqualTo(0.42);
+        assertThat(r.anomalyScore()).isEqualTo(0.42);
+        assertThat(r.trustScore()).isEqualTo(0.11);
+    }
+
+    @Test
+    void maxAnomalyAndZeroTrustCapsAtOne() {
+        DeterministicRequestRiskFusion f = new DeterministicRequestRiskFusion(1.0);
+        FusedRisk r = f.fuse(1.0, 0.0);
+        assertThat(r.fusedScore()).isEqualTo(1.0);
+        assertThat(r.anomalyScore()).isEqualTo(1.0);
+        assertThat(r.trustScore()).isZero();
+    }
+}

--- a/ai-sentinel-core/src/test/java/io/aisentinel/distributed/training/TrainingCandidateRecordTest.java
+++ b/ai-sentinel-core/src/test/java/io/aisentinel/distributed/training/TrainingCandidateRecordTest.java
@@ -27,6 +27,8 @@ class TrainingCandidateRecordTest {
             0.1,
             0.2,
             0.3,
+            null,
+            null,
             "ALLOW",
             "ENFORCE",
             true,
@@ -45,7 +47,7 @@ class TrainingCandidateRecordTest {
     @Test
     void invalidHashBecomesZeroHex() {
         var r = new TrainingCandidateRecord(
-            2,
+            TrainingCandidateRecord.SCHEMA_VERSION_2,
             "e",
             "t",
             "n",
@@ -58,6 +60,8 @@ class TrainingCandidateRecordTest {
             null,
             null,
             0.5,
+            null,
+            null,
             "MONITOR",
             "ENFORCE",
             true,

--- a/ai-sentinel-spring-boot-starter/src/main/java/io/aisentinel/autoconfigure/config/SentinelAutoConfiguration.java
+++ b/ai-sentinel-spring-boot-starter/src/main/java/io/aisentinel/autoconfigure/config/SentinelAutoConfiguration.java
@@ -1,6 +1,9 @@
 package io.aisentinel.autoconfigure.config;
 
 import io.aisentinel.core.SentinelPipeline;
+import io.aisentinel.core.fusion.DeterministicRequestRiskFusion;
+import io.aisentinel.core.fusion.NoopRequestRiskFusion;
+import io.aisentinel.core.fusion.RequestRiskFusion;
 import io.aisentinel.core.identity.spi.IdentityContextResolver;
 import io.aisentinel.core.identity.spi.IdentityResponseHook;
 import io.aisentinel.core.identity.spi.NoopIdentityContextResolver;
@@ -425,6 +428,21 @@ public class SentinelAutoConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
+    public RequestRiskFusion requestRiskFusion(SentinelProperties props) {
+        var fusion = props.getIdentity().getFusion();
+        if (fusion.isEnabled() && !props.getIdentity().isEnabled()) {
+            log.warn(
+                "ai.sentinel.identity.fusion.enabled=true but ai.sentinel.identity.enabled=false; "
+                    + "fusion has no effect until identity is enabled (no IdentityContext on requests).");
+        }
+        if (!fusion.isEnabled()) {
+            return NoopRequestRiskFusion.INSTANCE;
+        }
+        return new DeterministicRequestRiskFusion(fusion.getStrength());
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
     public SentinelPipeline sentinelPipeline(FeatureExtractor featureExtractor,
                                              CompositeScorer compositeScorer,
                                              PolicyEngine policyEngine,
@@ -436,7 +454,8 @@ public class SentinelAutoConfiguration {
                                              SentinelProperties props,
                                              ObjectProvider<IdentityContextResolver> identityContextResolverProvider,
                                              ObjectProvider<TrustEvaluator> trustEvaluatorProvider,
-                                             ObjectProvider<IdentityResponseHook> identityResponseHookProvider) {
+                                             ObjectProvider<IdentityResponseHook> identityResponseHookProvider,
+                                             RequestRiskFusion requestRiskFusion) {
         log.info("Sentinel pipeline configured (mode={})", props.getMode());
         String nodeId = props.getDistributed().getTrainingPublisherNodeId();
         if (nodeId == null) {
@@ -470,7 +489,8 @@ public class SentinelAutoConfiguration {
             props.getMode().name(),
             identityContextResolver,
             trustEvaluator,
-            identityResponseHook
+            identityResponseHook,
+            requestRiskFusion
         );
     }
 

--- a/ai-sentinel-spring-boot-starter/src/main/java/io/aisentinel/autoconfigure/config/SentinelProperties.java
+++ b/ai-sentinel-spring-boot-starter/src/main/java/io/aisentinel/autoconfigure/config/SentinelProperties.java
@@ -81,6 +81,22 @@ public class SentinelProperties {
         /** Phase 2 — local behavioral trust baselines and evaluation (only when {@link #enabled} is true). */
         @Valid
         private Trust trust = new Trust();
+        /** Phase 4 — fuse anomaly + trust before policy (default off; no effect without {@link #enabled}). */
+        @Valid
+        private Fusion fusion = new Fusion();
+    }
+
+    @Data
+    public static class Fusion {
+        /**
+         * When true, policy sees a fused risk derived from anomaly and trust when {@link Identity#enabled} is true and
+         * an {@link io.aisentinel.core.identity.model.IdentityContext} is present.
+         */
+        private boolean enabled = false;
+        /** Trust influence on fusion ({@code [0,1]}); higher = stronger amplification from low trust. */
+        @DecimalMin("0.0")
+        @DecimalMax("1.0")
+        private double strength = 0.35;
     }
 
     @Data

--- a/ai-sentinel-spring-boot-starter/src/main/java/io/aisentinel/autoconfigure/distributed/training/AsyncTrainingCandidatePublisher.java
+++ b/ai-sentinel-spring-boot-starter/src/main/java/io/aisentinel/autoconfigure/distributed/training/AsyncTrainingCandidatePublisher.java
@@ -120,6 +120,8 @@ public final class AsyncTrainingCandidatePublisher implements TrainingCandidateP
             request.statisticalScore(),
             request.isolationForestScore(),
             request.compositeScore(),
+            request.trustScore(),
+            request.fusedPolicyScore(),
             request.policyAction().name(),
             request.sentinelMode(),
             request.requestProceeded(),

--- a/ai-sentinel-spring-boot-starter/src/main/java/io/aisentinel/autoconfigure/distributed/training/TrainingCandidateJson.java
+++ b/ai-sentinel-spring-boot-starter/src/main/java/io/aisentinel/autoconfigure/distributed/training/TrainingCandidateJson.java
@@ -29,6 +29,12 @@ final class TrainingCandidateJson {
             m.put("isolationForestScore", r.isolationForestScore());
         }
         m.put("compositeScore", r.compositeScore());
+        if (r.trustScore() != null) {
+            m.put("trustScore", r.trustScore());
+        }
+        if (r.fusedPolicyScore() != null) {
+            m.put("fusedPolicyScore", r.fusedPolicyScore());
+        }
         m.put("policyAction", r.policyAction());
         m.put("sentinelMode", r.sentinelMode());
         m.put("requestProceeded", r.requestProceeded());

--- a/ai-sentinel-spring-boot-starter/src/test/java/io/aisentinel/autoconfigure/distributed/training/AsyncTrainingCandidatePublisherTest.java
+++ b/ai-sentinel-spring-boot-starter/src/test/java/io/aisentinel/autoconfigure/distributed/training/AsyncTrainingCandidatePublisherTest.java
@@ -227,7 +227,9 @@ class AsyncTrainingCandidatePublisherTest {
             "n1",
             "ENFORCE",
             true,
-            false
+            false,
+            null,
+            null
         );
     }
 

--- a/ai-sentinel-spring-boot-starter/src/test/java/io/aisentinel/autoconfigure/distributed/training/TrainingCandidateJsonTest.java
+++ b/ai-sentinel-spring-boot-starter/src/test/java/io/aisentinel/autoconfigure/distributed/training/TrainingCandidateJsonTest.java
@@ -17,7 +17,7 @@ class TrainingCandidateJsonTest {
         String epHash = TrainingFingerprintHashes.sha256HexUtf8(rawEndpoint);
         String ekHash = TrainingFingerprintHashes.sha256HexUtf8("ek");
         var record = new TrainingCandidateRecord(
-            2,
+            TrainingCandidateRecord.CURRENT_SCHEMA_VERSION,
             "550e8400-e29b-41d4-a716-446655440000",
             "tenant",
             "node",
@@ -30,6 +30,8 @@ class TrainingCandidateJsonTest {
             0.1,
             0.2,
             0.55,
+            0.9,
+            0.6,
             "MONITOR",
             "ENFORCE",
             true,
@@ -47,5 +49,7 @@ class TrainingCandidateJsonTest {
         assertThat(json).doesNotContain("\"enforcementKey\":");
         assertThat(m).doesNotContainKey("endpoint");
         assertThat(m).doesNotContainKey("enforcementKey");
+        assertThat(m).containsEntry("trustScore", 0.9);
+        assertThat(m).containsEntry("fusedPolicyScore", 0.6);
     }
 }

--- a/ai-sentinel-trainer/src/main/java/io/aisentinel/trainer/TrainingCandidateMessageParser.java
+++ b/ai-sentinel-trainer/src/main/java/io/aisentinel/trainer/TrainingCandidateMessageParser.java
@@ -22,7 +22,8 @@ public final class TrainingCandidateMessageParser {
     public TrainingCandidateRecord parse(String json) throws IOException {
         JsonNode n = mapper.readTree(json);
         int schema = n.path("schemaVersion").asInt(-1);
-        if (schema != TrainingCandidateRecord.CURRENT_SCHEMA_VERSION) {
+        if (schema != TrainingCandidateRecord.CURRENT_SCHEMA_VERSION
+            && schema != TrainingCandidateRecord.SCHEMA_VERSION_2) {
             throw new IOException("unsupported schemaVersion: " + schema);
         }
         String eventId = text(n, "eventId");
@@ -44,6 +45,12 @@ public final class TrainingCandidateMessageParser {
         String sentinelMode = text(n, "sentinelMode");
         boolean requestProceeded = n.path("requestProceeded").asBoolean(true);
         boolean startupGrace = n.path("startupGraceActive").asBoolean(false);
+        Double trustScore = schema >= TrainingCandidateRecord.CURRENT_SCHEMA_VERSION
+            ? readNullableDouble(n, "trustScore")
+            : null;
+        Double fusedPolicyScore = schema >= TrainingCandidateRecord.CURRENT_SCHEMA_VERSION
+            ? readNullableDouble(n, "fusedPolicyScore")
+            : null;
         return new TrainingCandidateRecord(
             schema,
             eventId,
@@ -58,6 +65,8 @@ public final class TrainingCandidateMessageParser {
             statScore,
             ifScore,
             composite,
+            trustScore,
+            fusedPolicyScore,
             policyAction,
             sentinelMode,
             requestProceeded,

--- a/ai-sentinel-trainer/src/test/java/io/aisentinel/trainer/TrainingCandidateMessageParserTest.java
+++ b/ai-sentinel-trainer/src/test/java/io/aisentinel/trainer/TrainingCandidateMessageParserTest.java
@@ -25,7 +25,29 @@ class TrainingCandidateMessageParserTest {
         TrainingCandidateRecord r = p.parse(json);
         assertThat(r.tenantId()).isEqualTo("default");
         assertThat(r.compositeScore()).isEqualTo(0.8);
+        assertThat(r.trustScore()).isNull();
+        assertThat(r.fusedPolicyScore()).isNull();
         assertThat(r.isolationForestFeatures()).containsExactly(1, 2, 3, 4, 5);
+    }
+
+    @Test
+    void parsesSchema3WithTrustAndFused() throws Exception {
+        String json = """
+            {"schemaVersion":3,"eventId":"e1","tenantId":"default","nodeId":"n","identityHash":"h",\
+            "endpointSha256Hex":"%s","enforcementKeySha256Hex":"%s","observedAtEpochMillis":1,\
+            "isolationForestFeatures":[1,2,3,4,5],"statisticalFeatures":[1,2,3,4,5,6,7],\
+            "compositeScore":0.35,"trustScore":0.1,"fusedPolicyScore":0.72,"policyAction":"THROTTLE",\
+            "sentinelMode":"ENFORCE","requestProceeded":true,"startupGraceActive":false}\
+            """.formatted(
+            "a".repeat(64),
+            "b".repeat(64)
+        );
+        TrainingCandidateMessageParser p = new TrainingCandidateMessageParser(new ObjectMapper());
+        TrainingCandidateRecord r = p.parse(json);
+        assertThat(r.schemaVersion()).isEqualTo(3);
+        assertThat(r.compositeScore()).isEqualTo(0.35);
+        assertThat(r.trustScore()).isEqualTo(0.1);
+        assertThat(r.fusedPolicyScore()).isEqualTo(0.72);
     }
 
     @Test


### PR DESCRIPTION
Adds a **pre-policy fusion** step that combines clamped anomaly risk with identity trust into a single score for `PolicyEngine`, while keeping scorers and threshold policy unchanged. Fusion is **off by default**, **fail-open**, and **explainable** via `FusedRisk` on `RequestContext`. Training export keeps **raw anomaly**, **trust**, and **fused policy** scores distinct (schema **3**) so downstream ML can separate signals; schema **2** messages still parse.
## What changed
### Core
- `RequestRiskFusion`, `DeterministicRequestRiskFusion`, `NoopRequestRiskFusion`, `FusedRisk`, `FusionContextKeys`
- `SentinelPipeline`: fusion after anomaly clamp, before `PolicyEngine.evaluate`
- `TrainingCandidatePublishRequest` / `TrainingCandidateRecord`: raw `compositeScore` + optional `trustScore` / `fusedPolicyScore`
### Starter
- `ai.sentinel.identity.fusion.*` configuration
- `RequestRiskFusion` bean and pipeline injection
- Startup warning if fusion is enabled but identity is disabled
### Trainer
- `