### PR TITLE
Fix locale-invariant header fingerprint normalization

### DIFF
--- a/ai-sentinel-core/src/main/java/io/aisentinel/core/feature/DefaultFeatureExtractor.java
+++ b/ai-sentinel-core/src/main/java/io/aisentinel/core/feature/DefaultFeatureExtractor.java
@@ -7,6 +7,7 @@ import jakarta.servlet.http.HttpServletRequest;
 
 import java.util.Enumeration;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicIntegerArray;
@@ -181,7 +182,7 @@ public final class DefaultFeatureExtractor implements FeatureExtractor {
             String name = names.nextElement();
             if (name != null && !name.equalsIgnoreCase("Authorization")) {
                 String v = request.getHeader(name);
-                h.put(name.toLowerCase(), v != null ? Integer.toString(v.length()) : "0");
+                h.put(name.toLowerCase(Locale.ROOT), v != null ? Integer.toString(v.length()) : "0");
             }
         }
         return h.hashCode();

--- a/ai-sentinel-core/src/test/java/io/aisentinel/core/feature/DefaultFeatureExtractorTest.java
+++ b/ai-sentinel-core/src/test/java/io/aisentinel/core/feature/DefaultFeatureExtractorTest.java
@@ -9,6 +9,8 @@ import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
 import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
@@ -99,5 +101,30 @@ class DefaultFeatureExtractorTest {
     void normalizePathParamsStaticMethod() {
         assertThat(DefaultFeatureExtractor.normalizePathParams("/api/users/123")).isEqualTo("/api/users/{id}");
         assertThat(DefaultFeatureExtractor.normalizePathParams("/api/items/abc")).isEqualTo("/api/items/abc");
+    }
+
+    @Test
+    void headerFingerprintIsLocaleInvariant() {
+        Locale old = Locale.getDefault();
+        try {
+            when(request.getRequestURI()).thenReturn("/api/hello");
+            when(request.getRemoteAddr()).thenReturn("192.168.1.1");
+            when(request.getParameterMap()).thenReturn(Collections.emptyMap());
+            when(request.getHeaderNames()).thenReturn(Collections.enumeration(List.of("If-Match")));
+            when(request.getHeader("If-Match")).thenReturn("etag-value");
+            when(request.getHeader("Content-Length")).thenReturn(null);
+
+            Locale.setDefault(Locale.US);
+            RequestFeatures us = new DefaultFeatureExtractor(new BaselineStore(Duration.ofMinutes(1), 1000))
+                .extract(request, "hash1", new RequestContext());
+
+            Locale.setDefault(Locale.forLanguageTag("tr-TR"));
+            RequestFeatures tr = new DefaultFeatureExtractor(new BaselineStore(Duration.ofMinutes(1), 1000))
+                .extract(request, "hash1", new RequestContext());
+
+            assertThat(tr.headerFingerprintHash()).isEqualTo(us.headerFingerprintHash());
+        } finally {
+            Locale.setDefault(old);
+        }
     }
 }

--- a/ai-sentinel-core/src/test/java/io/aisentinel/core/feature/DefaultFeatureExtractorTest.java
+++ b/ai-sentinel-core/src/test/java/io/aisentinel/core/feature/DefaultFeatureExtractorTest.java
@@ -110,7 +110,7 @@ class DefaultFeatureExtractorTest {
             when(request.getRequestURI()).thenReturn("/api/hello");
             when(request.getRemoteAddr()).thenReturn("192.168.1.1");
             when(request.getParameterMap()).thenReturn(Collections.emptyMap());
-            when(request.getHeaderNames()).thenReturn(Collections.enumeration(List.of("If-Match")));
+            when(request.getHeaderNames()).thenAnswer(inv -> Collections.enumeration(List.of("If-Match")));
             when(request.getHeader("If-Match")).thenReturn("etag-value");
             when(request.getHeader("Content-Length")).thenReturn(null);
 


### PR DESCRIPTION
## Summary
This PR fixes locale-sensitive header normalization in request feature extraction.

## What changed
- Switched header-name canonicalization to `Locale.ROOT` in header fingerprint generation.
- Added a regression test to verify fingerprint stability under `en-US` and `tr-TR` default locales.

## Why
Using default-locale lowercasing can produce different normalized header names in some locales (notably Turkish), causing inconsistent fingerprints for identical requests.

## Validation
- Added focused unit regression test in `DefaultFeatureExtractorTest`.
- Local Maven test execution is blocked in this container because Maven 4 requires Java 17+ while the runtime is Java 11.

@kabwama please review this PR.