### PR TITLE
feat(starter): make Sentinel filter ordering configurable and document Spring Security integration

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -168,7 +168,8 @@ Trusted entries may be literal IPs or **CIDR** prefixes.
 - **`SentinelAutoConfiguration`** registers the pipeline, filter, baseline store, scorers, policy engine (from properties), enforcement beans, telemetry, optional IF scheduler, and **`MicrometerSentinelMetrics`** when a **`MeterRegistry`** exists.
 - **`SentinelProperties`** binds `ai.sentinel.*` (relaxed names, e.g. `isolation-forest.enabled`).
 - **`SentinelEndpointAutoConfiguration`** exposes **`@Endpoint(id = "sentinel")`** → **`/actuator/sentinel`**.
-- Filter order is intended to run **after** authentication filters where **`SecurityContextHolder`** is populated (see starter code comments).
+- Sentinel filter registration uses `ai.sentinel.filter-order` (default `Ordered.LOWEST_PRECEDENCE - 100`), which is intended to run **after** authentication filters where **`SecurityContextHolder`** is populated in common setups.
+- Absolute ordering guarantees across every custom Spring/Security filter topology are not assumed; operators should set `ai.sentinel.filter-order` explicitly when their chain requires different placement.
 
 ---
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -168,7 +168,7 @@ Trusted entries may be literal IPs or **CIDR** prefixes.
 - **`SentinelAutoConfiguration`** registers the pipeline, filter, baseline store, scorers, policy engine (from properties), enforcement beans, telemetry, optional IF scheduler, and **`MicrometerSentinelMetrics`** when a **`MeterRegistry`** exists.
 - **`SentinelProperties`** binds `ai.sentinel.*` (relaxed names, e.g. `isolation-forest.enabled`).
 - **`SentinelEndpointAutoConfiguration`** exposes **`@Endpoint(id = "sentinel")`** → **`/actuator/sentinel`**.
-- Sentinel filter registration uses `ai.sentinel.filter-order` (default `Ordered.LOWEST_PRECEDENCE - 100`), which is intended to run **after** authentication filters where **`SecurityContextHolder`** is populated in common setups.
+- Sentinel filter registration uses `ai.sentinel.filter-order` (default `2147483547`, i.e. `Ordered.LOWEST_PRECEDENCE - 100` / `Integer.MAX_VALUE - 100`), which is intended to run **after** authentication filters where **`SecurityContextHolder`** is populated in common setups.
 - Absolute ordering guarantees across every custom Spring/Security filter topology are not assumed; operators should set `ai.sentinel.filter-order` explicitly when their chain requires different placement.
 
 ---

--- a/ai-sentinel-spring-boot-starter/src/main/java/io/aisentinel/autoconfigure/config/SentinelAutoConfiguration.java
+++ b/ai-sentinel-spring-boot-starter/src/main/java/io/aisentinel/autoconfigure/config/SentinelAutoConfiguration.java
@@ -65,6 +65,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.context.annotation.Conditional;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
 
 import java.util.HashSet;
 import java.util.List;
@@ -549,5 +550,17 @@ public class SentinelAutoConfiguration {
     @ConditionalOnMissingBean
     public SentinelFilter sentinelFilter(SentinelPipeline pipeline, SentinelProperties props, SentinelMetrics sentinelMetrics) {
         return new SentinelFilter(pipeline, props, sentinelMetrics);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean(name = "sentinelFilterRegistration")
+    public FilterRegistrationBean<SentinelFilter> sentinelFilterRegistration(SentinelFilter sentinelFilter,
+                                                                             SentinelProperties props) {
+        FilterRegistrationBean<SentinelFilter> registration = new FilterRegistrationBean<>();
+        registration.setFilter(sentinelFilter);
+        registration.setOrder(props.getFilterOrder());
+        registration.setName("aiSentinelFilter");
+        registration.addUrlPatterns("/*");
+        return registration;
     }
 }

--- a/ai-sentinel-spring-boot-starter/src/main/java/io/aisentinel/autoconfigure/config/SentinelAutoConfiguration.java
+++ b/ai-sentinel-spring-boot-starter/src/main/java/io/aisentinel/autoconfigure/config/SentinelAutoConfiguration.java
@@ -73,7 +73,7 @@ import java.util.Locale;
 import java.util.Set;
 
 /**
- * Primary Spring Boot auto-configuration for AI-Sentinel: pipeline beans, filter, optional Isolation Forest and
+ * Primary Spring Boot auto-configuration for AI-Sentinel: pipeline beans, servlet filter registration, optional Isolation Forest and
  * distributed features. Most beans use {@link ConditionalOnMissingBean} so applications can override extension points
  * ({@link io.aisentinel.core.feature.FeatureExtractor}, {@link io.aisentinel.core.policy.PolicyEngine}, etc.).
  * <p>
@@ -547,17 +547,12 @@ public class SentinelAutoConfiguration {
     }
 
     @Bean
-    @ConditionalOnMissingBean
-    public SentinelFilter sentinelFilter(SentinelPipeline pipeline, SentinelProperties props, SentinelMetrics sentinelMetrics) {
-        return new SentinelFilter(pipeline, props, sentinelMetrics);
-    }
-
-    @Bean
     @ConditionalOnMissingBean(name = "sentinelFilterRegistration")
-    public FilterRegistrationBean<SentinelFilter> sentinelFilterRegistration(SentinelFilter sentinelFilter,
-                                                                             SentinelProperties props) {
+    public FilterRegistrationBean<SentinelFilter> sentinelFilterRegistration(SentinelPipeline pipeline,
+                                                                             SentinelProperties props,
+                                                                             SentinelMetrics sentinelMetrics) {
         FilterRegistrationBean<SentinelFilter> registration = new FilterRegistrationBean<>();
-        registration.setFilter(sentinelFilter);
+        registration.setFilter(new SentinelFilter(pipeline, props, sentinelMetrics));
         registration.setOrder(props.getFilterOrder());
         registration.setName("aiSentinelFilter");
         registration.addUrlPatterns("/*");

--- a/ai-sentinel-spring-boot-starter/src/main/java/io/aisentinel/autoconfigure/config/SentinelProperties.java
+++ b/ai-sentinel-spring-boot-starter/src/main/java/io/aisentinel/autoconfigure/config/SentinelProperties.java
@@ -11,6 +11,7 @@ import lombok.Data;
 import org.hibernate.validator.constraints.time.DurationMax;
 import org.hibernate.validator.constraints.time.DurationMin;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.core.Ordered;
 import org.springframework.validation.annotation.Validated;
 
 import java.time.Duration;
@@ -43,6 +44,8 @@ public class SentinelProperties {
     private List<String> trustedProxies = List.of();
     /** After startup, enforcement is limited to MONITOR for this duration (0 disables). */
     private Duration startupGracePeriod = Duration.ZERO;
+    /** Servlet filter order for Sentinel; defaults near end of chain. */
+    private int filterOrder = Ordered.LOWEST_PRECEDENCE - 100;
     /** Whether throttle/quarantine keys are per identity only or identity+endpoint. */
     private EnforcementScope enforcementScope = EnforcementScope.IDENTITY_ENDPOINT;
     /** Min samples per key before using real score (cold-start); below this return warmup-score. Default 2. */

--- a/ai-sentinel-spring-boot-starter/src/main/java/io/aisentinel/autoconfigure/web/SentinelFilter.java
+++ b/ai-sentinel-spring-boot-starter/src/main/java/io/aisentinel/autoconfigure/web/SentinelFilter.java
@@ -9,8 +9,6 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.core.Ordered;
-import org.springframework.core.annotation.Order;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
@@ -24,7 +22,6 @@ import java.util.HexFormat;
  * Respects {@link io.aisentinel.autoconfigure.config.SentinelProperties#getExcludePaths()} and mode OFF/MONITOR/ENFORCE.
  */
 @Slf4j
-@Order(Ordered.LOWEST_PRECEDENCE - 100)
 @RequiredArgsConstructor
 public class SentinelFilter extends OncePerRequestFilter {
 

--- a/ai-sentinel-spring-boot-starter/src/test/java/io/aisentinel/autoconfigure/config/SentinelAutoConfigurationTest.java
+++ b/ai-sentinel-spring-boot-starter/src/test/java/io/aisentinel/autoconfigure/config/SentinelAutoConfigurationTest.java
@@ -13,6 +13,7 @@ import io.aisentinel.autoconfigure.distributed.quarantine.RedisClusterQuarantine
 import io.aisentinel.autoconfigure.distributed.quarantine.RedisClusterQuarantineWriter;
 import io.aisentinel.autoconfigure.distributed.throttle.RedisClusterThrottleStore;
 import io.aisentinel.autoconfigure.web.SentinelFilter;
+import io.aisentinel.core.SentinelPipeline;
 import io.aisentinel.core.identity.spi.IdentityContextResolver;
 import io.aisentinel.core.identity.spi.NoopIdentityContextResolver;
 import io.aisentinel.core.identity.spi.NoopTrustEvaluator;
@@ -23,6 +24,7 @@ import io.aisentinel.core.policy.NoopTrustPolicyAdjuster;
 import io.aisentinel.core.policy.TrustPolicyAdjuster;
 import io.aisentinel.core.identity.trust.BehavioralIdentityTrustEvaluator;
 import io.aisentinel.core.identity.trust.IdentityBehavioralBaselineStore;
+import io.aisentinel.core.metrics.SentinelMetrics;
 import io.aisentinel.core.model.RequestFeatures;
 import io.aisentinel.core.policy.EnforcementAction;
 import io.aisentinel.core.policy.PolicyEngine;
@@ -93,7 +95,10 @@ class SentinelAutoConfigurationTest {
             .withPropertyValues("ai.sentinel.enabled=true")
             .run(context -> {
                 assertThat(context).hasSingleBean(io.aisentinel.core.SentinelPipeline.class);
-                assertThat(context).hasSingleBean(SentinelFilter.class);
+                assertThat(context).doesNotHaveBean(SentinelFilter.class);
+                FilterRegistrationBean<?> registration = context.getBean("sentinelFilterRegistration",
+                    FilterRegistrationBean.class);
+                assertThat(registration.getFilter()).isInstanceOf(SentinelFilter.class);
             });
     }
 
@@ -119,6 +124,34 @@ class SentinelAutoConfigurationTest {
                     FilterRegistrationBean.class);
                 assertThat(registration.getOrder()).isEqualTo(1234);
             });
+    }
+
+    @Test
+    void customSentinelFilterRegistrationBeanSuppressesDefault() {
+        contextRunner
+            .withUserConfiguration(CustomSentinelFilterRegistrationConfig.class)
+            .withPropertyValues("ai.sentinel.enabled=true")
+            .run(context -> {
+                FilterRegistrationBean<?> registration = context.getBean("sentinelFilterRegistration",
+                    FilterRegistrationBean.class);
+                assertThat(registration.getOrder()).isEqualTo(42);
+                assertThat(registration.getFilter()).isInstanceOf(SentinelFilter.class);
+            });
+    }
+
+    @Configuration
+    static class CustomSentinelFilterRegistrationConfig {
+        @Bean(name = "sentinelFilterRegistration")
+        FilterRegistrationBean<SentinelFilter> sentinelFilterRegistration(SentinelPipeline pipeline,
+                                                                          SentinelProperties props,
+                                                                          SentinelMetrics sentinelMetrics) {
+            FilterRegistrationBean<SentinelFilter> reg = new FilterRegistrationBean<>();
+            reg.setFilter(new SentinelFilter(pipeline, props, sentinelMetrics));
+            reg.setOrder(42);
+            reg.setName("customSentinelFilter");
+            reg.addUrlPatterns("/*");
+            return reg;
+        }
     }
 
     @Test

--- a/ai-sentinel-spring-boot-starter/src/test/java/io/aisentinel/autoconfigure/config/SentinelAutoConfigurationTest.java
+++ b/ai-sentinel-spring-boot-starter/src/test/java/io/aisentinel/autoconfigure/config/SentinelAutoConfigurationTest.java
@@ -47,8 +47,10 @@ import org.springframework.boot.test.system.CapturedOutput;
 import org.springframework.boot.test.system.OutputCaptureExtension;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.WebApplicationContextRunner;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.Ordered;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.data.redis.core.script.RedisScript;
@@ -92,6 +94,30 @@ class SentinelAutoConfigurationTest {
             .run(context -> {
                 assertThat(context).hasSingleBean(io.aisentinel.core.SentinelPipeline.class);
                 assertThat(context).hasSingleBean(SentinelFilter.class);
+            });
+    }
+
+    @Test
+    void sentinelFilterRegistrationUsesDefaultOrder() {
+        contextRunner
+            .withPropertyValues("ai.sentinel.enabled=true")
+            .run(context -> {
+                FilterRegistrationBean<?> registration = context.getBean("sentinelFilterRegistration",
+                    FilterRegistrationBean.class);
+                assertThat(registration.getOrder()).isEqualTo(Ordered.LOWEST_PRECEDENCE - 100);
+            });
+    }
+
+    @Test
+    void sentinelFilterRegistrationUsesConfiguredOrder() {
+        contextRunner
+            .withPropertyValues(
+                "ai.sentinel.enabled=true",
+                "ai.sentinel.filter-order=1234")
+            .run(context -> {
+                FilterRegistrationBean<?> registration = context.getBean("sentinelFilterRegistration",
+                    FilterRegistrationBean.class);
+                assertThat(registration.getOrder()).isEqualTo(1234);
             });
     }
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -12,7 +12,7 @@ Properties use Spring Boot relaxed binding (`ai.sentinel.*`, `aisentinel.trainer
 | `ai.sentinel.mode` | `ENFORCE` | `OFF`, `MONITOR`, `ENFORCE` |
 | `ai.sentinel.exclude-paths` | actuator, health, static, favicon | Comma-separated Ant-style patterns |
 | `ai.sentinel.trusted-proxies` | _(empty)_ | IPs or CIDRs; when remote matches, client IP from forwarded headers (see trusted proxy handling in [`ARCHITECTURE.md`](../ARCHITECTURE.md)) |
-| `ai.sentinel.filter-order` | `LOWEST_PRECEDENCE - 100` | Servlet filter order for Sentinel; adjust when you need Sentinel before/after other app filters or Spring Security chain behavior |
+| `ai.sentinel.filter-order` | `2147483547` (same as `Ordered.LOWEST_PRECEDENCE - 100`, i.e. `Integer.MAX_VALUE - 100`) | Servlet filter order for Sentinel; adjust when you need Sentinel before/after other app filters or Spring Security chain behavior |
 | `ai.sentinel.threshold-moderate` … `threshold-critical` | `0.2` … `0.8` | Strictly increasing, in `[0,1]` |
 | `ai.sentinel.warmup-min-samples` / `warmup-score` | `2` / `0.4` | Cold-start statistical behavior |
 | `ai.sentinel.startup-grace-period` | `0` | Duration (e.g. `5m`) enforcing monitor-only after startup |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -12,6 +12,7 @@ Properties use Spring Boot relaxed binding (`ai.sentinel.*`, `aisentinel.trainer
 | `ai.sentinel.mode` | `ENFORCE` | `OFF`, `MONITOR`, `ENFORCE` |
 | `ai.sentinel.exclude-paths` | actuator, health, static, favicon | Comma-separated Ant-style patterns |
 | `ai.sentinel.trusted-proxies` | _(empty)_ | IPs or CIDRs; when remote matches, client IP from forwarded headers (see trusted proxy handling in [`ARCHITECTURE.md`](../ARCHITECTURE.md)) |
+| `ai.sentinel.filter-order` | `LOWEST_PRECEDENCE - 100` | Servlet filter order for Sentinel; adjust when you need Sentinel before/after other app filters or Spring Security chain behavior |
 | `ai.sentinel.threshold-moderate` … `threshold-critical` | `0.2` … `0.8` | Strictly increasing, in `[0,1]` |
 | `ai.sentinel.warmup-min-samples` / `warmup-score` | `2` / `0.4` | Cold-start statistical behavior |
 | `ai.sentinel.startup-grace-period` | `0` | Duration (e.g. `5m`) enforcing monitor-only after startup |


### PR DESCRIPTION
This PR addresses the filter-ordering documentation/behavior gap raised in GitHub Issue #<ISSUE_NUMBER>.

Sentinel previously relied on a fixed filter order (`LOWEST_PRECEDENCE - 100`) with intent documented but not configurable at runtime. In applications with custom filter chains and Spring Security ordering differences, this could produce identity/enforcement behavior that differed from operator expectations.

## What changed
- Added `ai.sentinel.filter-order` to `SentinelProperties` (default remains `Ordered.LOWEST_PRECEDENCE - 100`).
- Registered `SentinelFilter` via `FilterRegistrationBean` and applied `props.getFilterOrder()` for runtime order control.
- Removed hardcoded `@Order(...)` from `SentinelFilter` so filter order is controlled in one place.
- Added tests in `SentinelAutoConfigurationTest` for:
  - default order behavior
  - custom configured order behavior
- Updated docs:
  - `docs/configuration.md` (new property reference)
  - `ARCHITECTURE.md` (explicit ordering guarantees/caveats)

## Why
- Makes filter placement explicit and configurable for real Spring Boot/Spring Security stacks.
- Reduces ambiguity around when `SecurityContextHolder` is populated relative to Sentinel processing.
- Improves operator control without changing default behavior.

## Backward compatibility
- Default behavior is preserved (`LOWEST_PRECEDENCE - 100`).
- Existing users do not need configuration changes unless custom ordering is desired.

## Validation
- Ran targeted tests:
  - `SentinelAutoConfigurationTest`
  - `SentinelFilterProxyTest`

## Linked issue
Closes [issue](https://github.com/CollinKabwama/ai-sentinel/issues/8)