### PR TITLE
perf(starter): reduce SentinelFilter hot-path digest and security reflection

### DIFF
--- a/ai-sentinel-spring-boot-starter/src/main/java/io/aisentinel/autoconfigure/web/IdentityHasher.java
+++ b/ai-sentinel-spring-boot-starter/src/main/java/io/aisentinel/autoconfigure/web/IdentityHasher.java
@@ -1,0 +1,28 @@
+package io.aisentinel.autoconfigure.web;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
+
+/** Thread-local SHA-256 for identity strings; avoids allocating a new {@link MessageDigest} per request. */
+final class IdentityHasher {
+
+    private static final ThreadLocal<MessageDigest> SHA256 = ThreadLocal.withInitial(() -> {
+        try {
+            return MessageDigest.getInstance("SHA-256");
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 is required for identity hashing", e);
+        }
+    });
+
+    private IdentityHasher() {
+    }
+
+    static String sha256Hex(String s) {
+        byte[] input = (s != null ? s : "").getBytes(StandardCharsets.UTF_8);
+        MessageDigest md = SHA256.get();
+        md.reset();
+        return HexFormat.of().formatHex(md.digest(input));
+    }
+}

--- a/ai-sentinel-spring-boot-starter/src/main/java/io/aisentinel/autoconfigure/web/IdentityHasher.java
+++ b/ai-sentinel-spring-boot-starter/src/main/java/io/aisentinel/autoconfigure/web/IdentityHasher.java
@@ -8,6 +8,8 @@ import java.util.HexFormat;
 /** Thread-local SHA-256 for identity strings; avoids allocating a new {@link MessageDigest} per request. */
 final class IdentityHasher {
 
+    private static final HexFormat HEX = HexFormat.of();
+
     private static final ThreadLocal<MessageDigest> SHA256 = ThreadLocal.withInitial(() -> {
         try {
             return MessageDigest.getInstance("SHA-256");
@@ -23,6 +25,6 @@ final class IdentityHasher {
         byte[] input = (s != null ? s : "").getBytes(StandardCharsets.UTF_8);
         MessageDigest md = SHA256.get();
         md.reset();
-        return HexFormat.of().formatHex(md.digest(input));
+        return HEX.formatHex(md.digest(input));
     }
 }

--- a/ai-sentinel-spring-boot-starter/src/main/java/io/aisentinel/autoconfigure/web/SentinelFilter.java
+++ b/ai-sentinel-spring-boot-starter/src/main/java/io/aisentinel/autoconfigure/web/SentinelFilter.java
@@ -14,10 +14,6 @@ import org.springframework.core.annotation.Order;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
-import java.nio.charset.StandardCharsets;
-import java.util.HexFormat;
 
 /**
  * Servlet filter that runs the {@link io.aisentinel.core.SentinelPipeline} once per request (after auth when ordered late).
@@ -85,29 +81,11 @@ public class SentinelFilter extends OncePerRequestFilter {
 
     private String resolveIdentityHash(HttpServletRequest request) {
         String identity = ClientIpResolver.resolveClientIp(request, props.getTrustedProxies());
-        try {
-            Object ctx = Class.forName("org.springframework.security.core.context.SecurityContextHolder")
-                .getMethod("getContext").invoke(null);
-            if (ctx != null) {
-                Object auth = ctx.getClass().getMethod("getAuthentication").invoke(ctx);
-                if (auth != null && Boolean.TRUE.equals(auth.getClass().getMethod("isAuthenticated").invoke(auth))) {
-                    Object principal = auth.getClass().getMethod("getPrincipal").invoke(auth);
-                    if (principal != null && !"anonymousUser".equals(principal.toString())) {
-                        identity = auth.getClass().getMethod("getName").invoke(auth).toString();
-                    }
-                }
-            }
-        } catch (Exception ignored) { }
-        return hash(identity);
-    }
-
-    private static String hash(String s) {
-        try {
-            byte[] digest = MessageDigest.getInstance("SHA-256").digest((s != null ? s : "").getBytes(StandardCharsets.UTF_8));
-            return HexFormat.of().formatHex(digest);
-        } catch (NoSuchAlgorithmException e) {
-            return String.valueOf((s != null ? s : "").hashCode());
+        String principalName = SpringSecurityPrincipalBridge.resolveAuthenticatedPrincipalName();
+        if (principalName != null) {
+            identity = principalName;
         }
+        return IdentityHasher.sha256Hex(identity);
     }
 
     private static String maskHash(String h) {

--- a/ai-sentinel-spring-boot-starter/src/main/java/io/aisentinel/autoconfigure/web/SpringSecurityPrincipalBridge.java
+++ b/ai-sentinel-spring-boot-starter/src/main/java/io/aisentinel/autoconfigure/web/SpringSecurityPrincipalBridge.java
@@ -1,5 +1,7 @@
 package io.aisentinel.autoconfigure.web;
 
+import lombok.extern.slf4j.Slf4j;
+
 import java.lang.reflect.Method;
 
 /**
@@ -7,6 +9,7 @@ import java.lang.reflect.Method;
  * compile-time dependency on {@code spring-security-core}. Reflection targets are resolved once; the per-request path
  * only invokes cached {@link Method} handles.
  */
+@Slf4j
 final class SpringSecurityPrincipalBridge {
 
     private static final Bridge BRIDGE = Bridge.load();
@@ -51,9 +54,9 @@ final class SpringSecurityPrincipalBridge {
                 Method getPrincipal = authentication.getMethod("getPrincipal");
                 Method getName = authentication.getMethod("getName");
                 return new Bridge(getContext, getAuthentication, isAuthenticated, getPrincipal, getName, true);
-            } catch (ClassNotFoundException | NoSuchMethodException e) {
-                return noop();
-            } catch (LinkageError e) {
+            } catch (ReflectiveOperationException | LinkageError | SecurityException e) {
+                // ReflectiveOperationException: ClassNotFoundException, NoSuchMethodException, etc.
+                // LinkageError: includes NoClassDefFoundError and ExceptionInInitializerError from broken Security static init
                 return noop();
             }
         }
@@ -82,6 +85,7 @@ final class SpringSecurityPrincipalBridge {
                 Object name = getName.invoke(auth);
                 return name != null ? name.toString() : null;
             } catch (ReflectiveOperationException e) {
+                log.debug("SpringSecurityPrincipalBridge: failed to resolve principal, falling back to IP identity", e);
                 return null;
             }
         }

--- a/ai-sentinel-spring-boot-starter/src/main/java/io/aisentinel/autoconfigure/web/SpringSecurityPrincipalBridge.java
+++ b/ai-sentinel-spring-boot-starter/src/main/java/io/aisentinel/autoconfigure/web/SpringSecurityPrincipalBridge.java
@@ -1,0 +1,89 @@
+package io.aisentinel.autoconfigure.web;
+
+import java.lang.reflect.Method;
+
+/**
+ * Resolves the authenticated principal name from Spring Security when it is on the classpath, without a hard
+ * compile-time dependency on {@code spring-security-core}. Reflection targets are resolved once; the per-request path
+ * only invokes cached {@link Method} handles.
+ */
+final class SpringSecurityPrincipalBridge {
+
+    private static final Bridge BRIDGE = Bridge.load();
+
+    private SpringSecurityPrincipalBridge() {
+    }
+
+    /**
+     * @return authenticated non-anonymous principal name, or {@code null} if Security is absent, not authenticated,
+     * or resolution fails
+     */
+    static String resolveAuthenticatedPrincipalName() {
+        return BRIDGE.resolve();
+    }
+
+    private static final class Bridge {
+        private final Method getContext;
+        private final Method getAuthentication;
+        private final Method isAuthenticated;
+        private final Method getPrincipal;
+        private final Method getName;
+        private final boolean active;
+
+        private Bridge(Method getContext, Method getAuthentication, Method isAuthenticated, Method getPrincipal,
+                       Method getName, boolean active) {
+            this.getContext = getContext;
+            this.getAuthentication = getAuthentication;
+            this.isAuthenticated = isAuthenticated;
+            this.getPrincipal = getPrincipal;
+            this.getName = getName;
+            this.active = active;
+        }
+
+        static Bridge load() {
+            try {
+                Class<?> holder = Class.forName("org.springframework.security.core.context.SecurityContextHolder");
+                Class<?> securityContext = Class.forName("org.springframework.security.core.context.SecurityContext");
+                Class<?> authentication = Class.forName("org.springframework.security.core.Authentication");
+                Method getContext = holder.getMethod("getContext");
+                Method getAuthentication = securityContext.getMethod("getAuthentication");
+                Method isAuthenticated = authentication.getMethod("isAuthenticated");
+                Method getPrincipal = authentication.getMethod("getPrincipal");
+                Method getName = authentication.getMethod("getName");
+                return new Bridge(getContext, getAuthentication, isAuthenticated, getPrincipal, getName, true);
+            } catch (ClassNotFoundException | NoSuchMethodException e) {
+                return noop();
+            } catch (LinkageError e) {
+                return noop();
+            }
+        }
+
+        private static Bridge noop() {
+            return new Bridge(null, null, null, null, null, false);
+        }
+
+        String resolve() {
+            if (!active) {
+                return null;
+            }
+            try {
+                Object ctx = getContext.invoke(null);
+                if (ctx == null) {
+                    return null;
+                }
+                Object auth = getAuthentication.invoke(ctx);
+                if (auth == null || !Boolean.TRUE.equals(isAuthenticated.invoke(auth))) {
+                    return null;
+                }
+                Object principal = getPrincipal.invoke(auth);
+                if (principal == null || "anonymousUser".equals(principal.toString())) {
+                    return null;
+                }
+                Object name = getName.invoke(auth);
+                return name != null ? name.toString() : null;
+            } catch (ReflectiveOperationException e) {
+                return null;
+            }
+        }
+    }
+}

--- a/ai-sentinel-spring-boot-starter/src/test/java/io/aisentinel/autoconfigure/web/IdentityHasherTest.java
+++ b/ai-sentinel-spring-boot-starter/src/test/java/io/aisentinel/autoconfigure/web/IdentityHasherTest.java
@@ -1,0 +1,46 @@
+package io.aisentinel.autoconfigure.web;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class IdentityHasherTest {
+
+    @Test
+    void sha256Hex_matchesKnownVectorForEmptyString() {
+        assertThat(IdentityHasher.sha256Hex(""))
+            .isEqualTo("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
+    }
+
+    @Test
+    void sha256Hex_isStableAcrossRepeatedCalls() {
+        String first = IdentityHasher.sha256Hex("same-input");
+        String second = IdentityHasher.sha256Hex("same-input");
+        assertThat(second).isEqualTo(first);
+    }
+
+    @Test
+    void sha256Hex_concurrentCallsMatchSequential() throws Exception {
+        String input = "concurrent-identity";
+        String expected = IdentityHasher.sha256Hex(input);
+        ExecutorService pool = Executors.newFixedThreadPool(8);
+        try {
+            List<Callable<String>> tasks = new ArrayList<>();
+            for (int i = 0; i < 64; i++) {
+                tasks.add(() -> IdentityHasher.sha256Hex(input));
+            }
+            for (Future<String> f : pool.invokeAll(tasks)) {
+                assertThat(f.get()).isEqualTo(expected);
+            }
+        } finally {
+            pool.shutdown();
+        }
+    }
+}

--- a/ai-sentinel-spring-boot-starter/src/test/java/io/aisentinel/autoconfigure/web/IdentityHasherTest.java
+++ b/ai-sentinel-spring-boot-starter/src/test/java/io/aisentinel/autoconfigure/web/IdentityHasherTest.java
@@ -14,6 +14,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 class IdentityHasherTest {
 
     @Test
+    void sha256Hex_nullInputTreatedAsEmptyString() {
+        assertThat(IdentityHasher.sha256Hex(null)).isEqualTo(IdentityHasher.sha256Hex(""));
+    }
+
+    @Test
     void sha256Hex_matchesKnownVectorForEmptyString() {
         assertThat(IdentityHasher.sha256Hex(""))
             .isEqualTo("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");

--- a/ai-sentinel-spring-boot-starter/src/test/java/io/aisentinel/autoconfigure/web/SpringSecurityPrincipalBridgeTest.java
+++ b/ai-sentinel-spring-boot-starter/src/test/java/io/aisentinel/autoconfigure/web/SpringSecurityPrincipalBridgeTest.java
@@ -1,0 +1,53 @@
+package io.aisentinel.autoconfigure.web;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SpringSecurityPrincipalBridgeTest {
+
+    @AfterEach
+    void clearContext() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    void returnsPrincipalNameWhenAuthenticated() {
+        UsernamePasswordAuthenticationToken auth = new UsernamePasswordAuthenticationToken(
+            "alice", "n/a", List.of(new SimpleGrantedAuthority("ROLE_USER")));
+        SecurityContextHolder.getContext().setAuthentication(auth);
+
+        assertThat(SpringSecurityPrincipalBridge.resolveAuthenticatedPrincipalName()).isEqualTo("alice");
+    }
+
+    @Test
+    void returnsNullWhenAnonymousPrincipal() {
+        AnonymousAuthenticationToken auth = new AnonymousAuthenticationToken(
+            "key", "anonymousUser", List.of(new SimpleGrantedAuthority("ROLE_ANONYMOUS")));
+        SecurityContextHolder.getContext().setAuthentication(auth);
+
+        assertThat(SpringSecurityPrincipalBridge.resolveAuthenticatedPrincipalName()).isNull();
+    }
+
+    @Test
+    void returnsNullWhenNotAuthenticated() {
+        UsernamePasswordAuthenticationToken auth = new UsernamePasswordAuthenticationToken("bob", "n/a");
+        SecurityContextHolder.getContext().setAuthentication(auth);
+
+        assertThat(SpringSecurityPrincipalBridge.resolveAuthenticatedPrincipalName()).isNull();
+    }
+
+    @Test
+    void returnsNullWhenNoAuthentication() {
+        SecurityContextHolder.clearContext();
+
+        assertThat(SpringSecurityPrincipalBridge.resolveAuthenticatedPrincipalName()).isNull();
+    }
+}


### PR DESCRIPTION
Closes [](https://github.com/CollinKabwama/ai-sentinel/issues/7)

Reduces per-request overhead in `SentinelFilter` when Sentinel is enabled and the path is not excluded.

## Changes
- **Identity hashing:** reuse a per-thread `MessageDigest` for SHA-256 (`IdentityHasher`) instead of `MessageDigest.getInstance("SHA-256")` on every request.
- **Spring Security (optional classpath):** cache `Method` handles once in `SpringSecurityPrincipalBridge`; per-request path only invokes cached reflection (no repeated `Class.forName` / `getMethod`).